### PR TITLE
Task creation view fix

### DIFF
--- a/app/src/main/res/layout/activity_item_view.xml
+++ b/app/src/main/res/layout/activity_item_view.xml
@@ -48,12 +48,13 @@
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/textInputLayout"
-            android:layout_width="243dp"
-            android:layout_height="53dp">
+            android:layout_width="0dp"
+            android:layout_height="53dp"
+            android:layout_weight="1">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/new_task_text"
-                android:layout_width="233dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/task_creation_placeholder"
                 android:inputType="textShortMessage"
@@ -65,9 +66,8 @@
         <Button
             android:id="@+id/new_task_btn"
             style="@style/Widget.AppCompat.Button"
-            android:layout_width="0dp"
+            android:layout_width="75dp"
             android:layout_height="match_parent"
-            android:layout_weight="1"
             android:backgroundTint="#673AB7"
             android:onClick="addTask"
             android:text="@string/plus"


### PR DESCRIPTION
Closes #33 

When the task creation feature was introduced, the related test in CI was failing. The reason was that due to the CI emulator being too small, the text field took too much space, pushing the " + " button off-screen. The workaround was to make the text field smaller.

This fixes the issue by making the " + " button fixed size, and having the text field scale to the remaining space on the left.