### PR TITLE
db: Create Database powered by Firebase Storage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-storage'
     implementation 'com.google.code.gson:gson:2.8.6'
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:3.8.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'androidx.test:runner:1.3.0'

--- a/app/src/main/java/com/github/steroidteam/todolist/database/FirebaseDatabase.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/database/FirebaseDatabase.java
@@ -1,0 +1,140 @@
+package com.github.steroidteam.todolist.database;
+
+import androidx.annotation.NonNull;
+
+import com.github.steroidteam.todolist.filestorage.FirebaseFileStorageService;
+import com.github.steroidteam.todolist.todo.Task;
+import com.github.steroidteam.todolist.todo.TodoList;
+import com.github.steroidteam.todolist.util.JSONSerializer;
+import com.google.firebase.auth.FirebaseUser;
+import com.google.firebase.storage.FirebaseStorage;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+public class FirebaseDatabase implements Database {
+    private static final String TODO_LIST_PATH = "/todo-lists";
+    private final FirebaseFileStorageService storageService;
+
+    // TODO: Run Database operations asynchronously.
+    public FirebaseDatabase(@NonNull FirebaseFileStorageService storageService) {
+        Objects.requireNonNull(storageService);
+
+        this.storageService = storageService;
+    }
+
+    @Override
+    public void putTodoList(@NonNull TodoList list) throws DatabaseException {
+        Objects.requireNonNull(list);
+        String targetPath = TODO_LIST_PATH + list.getId().toString() + ".json";
+
+        // Serialize the task as an UTF-8 encoded JSON object.
+        byte[] fileBytes = JSONSerializer.serializeTodoList(list).getBytes(StandardCharsets.UTF_8);
+
+        try {
+            this.storageService.upload(fileBytes, targetPath).get();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new DatabaseException(e.toString());
+        }
+    }
+
+    @Override
+    public void removeTodoList(@NonNull UUID todoListID) throws DatabaseException {
+        Objects.requireNonNull(todoListID);
+        String targetPath = TODO_LIST_PATH + todoListID.toString() + ".json";
+
+        try {
+            this.storageService.delete(targetPath).get();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new DatabaseException(e.toString());
+        }
+    }
+
+    @Override
+    public TodoList getTodoList(@NonNull UUID todoListID) throws DatabaseException {
+        Objects.requireNonNull(todoListID);
+        String targetPath = TODO_LIST_PATH + todoListID.toString() + ".json";
+
+        try {
+            String serializedList = new String(
+                    this.storageService.download(targetPath).get(),
+                    StandardCharsets.UTF_8
+            );
+            return JSONSerializer.deserializeTodoList(serializedList);
+        } catch (ExecutionException | InterruptedException e) {
+            throw new DatabaseException(e.toString());
+        }
+    }
+
+    @Override
+    public void putTask(@NonNull UUID todoListID, @NonNull Task task) throws DatabaseException {
+        Objects.requireNonNull(todoListID);
+        Objects.requireNonNull(task);
+        String listPath = TODO_LIST_PATH + todoListID.toString() + ".json";
+
+        // Fetch the remote list that we are about to update.
+        try {
+            this.storageService.download(listPath)
+                    // Deserialize it.
+                    .thenApply(serializedList -> new String(serializedList, StandardCharsets.UTF_8))
+                    .thenApply(JSONSerializer::deserializeTodoList)
+                    // Add the new task to the object.
+                    .thenApply(todoList -> {
+                        todoList.addTask(task);
+                        return todoList;
+                    })
+                    // Re-serialize and upload the new object.
+                    .thenApply(JSONSerializer::serializeTodoList)
+                    .thenApply(serializedTodoList -> serializedTodoList.getBytes(StandardCharsets.UTF_8))
+                    .thenApply(bytes -> this.storageService.upload(bytes, listPath)).get();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new DatabaseException(e.toString());
+        }
+    }
+
+    @Override
+    public void removeTask(@NonNull UUID todoListID, @NonNull Integer taskIndex) throws DatabaseException {
+        Objects.requireNonNull(todoListID);
+        Objects.requireNonNull(taskIndex);
+        String listPath = TODO_LIST_PATH + todoListID.toString() + ".json";
+
+        // Fetch the remote list that we are about to update.
+        try {
+            this.storageService.download(listPath)
+                    // Deserialize it.
+                    .thenApply(serializedList -> new String(serializedList, StandardCharsets.UTF_8))
+                    .thenApply(JSONSerializer::deserializeTodoList)
+                    // Remove the task from the object.
+                    .thenApply(todoList -> {
+                        todoList.removeTask(taskIndex);
+                        return todoList;
+                    })
+                    // Re-serialize and upload the new object.
+                    .thenApply(JSONSerializer::serializeTodoList)
+                    .thenApply(serializedTodoList -> serializedTodoList.getBytes(StandardCharsets.UTF_8))
+                    .thenApply(bytes -> this.storageService.upload(bytes, listPath)).get();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new DatabaseException(e.toString());
+        }
+    }
+
+    @Override
+    public Task getTask(@NonNull UUID todoListID, @NonNull Integer taskIndex) throws DatabaseException {
+        Objects.requireNonNull(todoListID);
+        Objects.requireNonNull(taskIndex);
+        String listPath = TODO_LIST_PATH + todoListID.toString() + ".json";
+
+        // Fetch the remote list that we are about to update.
+        try {
+            return this.storageService.download(listPath)
+                    // Deserialize it.
+                    .thenApply(serializedList -> new String(serializedList, StandardCharsets.UTF_8))
+                    .thenApply(JSONSerializer::deserializeTodoList)
+                    .thenApply(todoList -> todoList.getTask(taskIndex)).get();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new DatabaseException(e.toString());
+        }
+    }
+}

--- a/app/src/main/java/com/github/steroidteam/todolist/todo/TodoList.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/todo/TodoList.java
@@ -1,5 +1,7 @@
 package com.github.steroidteam.todolist.todo;
 
+import androidx.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -91,5 +93,13 @@ public class TodoList {
         str.append("}");
 
         return str.toString();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TodoList todoList = (TodoList) o;
+        return todoList.getId().equals(this.getId());
     }
 }

--- a/app/src/main/java/com/github/steroidteam/todolist/util/JSONSerializer.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/util/JSONSerializer.java
@@ -6,14 +6,13 @@ import com.github.steroidteam.todolist.todo.TodoList;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import java.text.DateFormat;
 import java.util.Objects;
 
 public class JSONSerializer {
     private static final Gson gson = new GsonBuilder()
             // Date serialization might depend on the system, so let's make it deterministic
             // across platforms.
-            .setDateFormat(DateFormat.FULL, DateFormat.FULL).create();
+            .setDateFormat("yyyy-MM-dd HH:mm:ss.SSS").create();
 
     /**
      * Transforms a TodoList object into a JSON object.

--- a/app/src/test/java/com/github/steroidteam/todolist/database/FirebaseDatabaseTest.java
+++ b/app/src/test/java/com/github/steroidteam/todolist/database/FirebaseDatabaseTest.java
@@ -1,0 +1,371 @@
+package com.github.steroidteam.todolist.database;
+
+import com.github.steroidteam.todolist.filestorage.FirebaseFileStorageService;
+import com.github.steroidteam.todolist.todo.Task;
+import com.github.steroidteam.todolist.todo.TodoList;
+import com.github.steroidteam.todolist.util.JSONSerializer;
+import com.google.android.gms.tasks.RuntimeExecutionException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.nio.charset.StandardCharsets;
+import java.text.DateFormat;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyByte;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FirebaseDatabaseTest {
+    private static final String TODO_LIST_PATH = "/todo-lists";
+
+    @Mock
+    FirebaseFileStorageService storageService;
+
+    @Test
+    public void constructorRejectsNullStorageService() {
+        assertThrows(NullPointerException.class, () -> {
+            new FirebaseDatabase(null);
+        });
+    }
+
+    @Test
+    public void putTodoListRejectsNullList() {
+        assertThrows(NullPointerException.class, () -> {
+            new FirebaseDatabase(storageService).putTodoList(null);
+        });
+    }
+
+    @Test
+    public void putTodoListWorks() throws DatabaseException {
+        final TodoList todoList = new TodoList("My list");
+        final String expectedPath = TODO_LIST_PATH + todoList.getId().toString() + ".json";
+        final byte[] serializedList =
+                JSONSerializer.serializeTodoList(todoList).getBytes(StandardCharsets.UTF_8);
+
+        // Return a future like the one that the FirebaseFileStorageService would produce after
+        // successfully uploading the file.
+        final CompletableFuture<String> completedFuture = CompletableFuture.completedFuture(expectedPath);
+        doReturn(completedFuture).when(storageService).upload(any(), eq(expectedPath));
+
+        // Try to add a valid list.
+        final FirebaseDatabase database = new FirebaseDatabase(storageService);
+        database.putTodoList(todoList);
+
+        verify(storageService).upload(serializedList, expectedPath);
+    }
+
+    @Test
+    public void putTodoListThrowsDatabaseExceptionOnError() {
+        final TodoList todoList = new TodoList("My list");
+        final String expectedPath = TODO_LIST_PATH + todoList.getId().toString() + ".json";
+        final byte[] serializedList =
+                JSONSerializer.serializeTodoList(todoList).getBytes(StandardCharsets.UTF_8);
+
+        // Return a future that simulates an error during the upload.
+        final CompletableFuture<String> failingFuture = new CompletableFuture<>();
+        failingFuture.completeExceptionally(new RuntimeException());
+        doReturn(failingFuture).when(storageService).upload(any(), eq(expectedPath));
+
+        final FirebaseDatabase database = new FirebaseDatabase(storageService);
+
+        assertThrows(DatabaseException.class, () -> database.putTodoList(todoList));
+        verify(storageService).upload(serializedList, expectedPath);
+    }
+
+    @Test
+    public void removeTodoListRejectsNullTodoListID() {
+        assertThrows(NullPointerException.class, () -> {
+            new FirebaseDatabase(storageService).removeTodoList(null);
+        });
+    }
+
+    @Test
+    public void removeTodoListWorks() throws DatabaseException {
+        final UUID todoListID = UUID.randomUUID();
+        final String expectedPath = TODO_LIST_PATH + todoListID.toString() + ".json";
+
+        // Return a future like the one that the FirebaseFileStorageService would produce after
+        // successfully removing the file.
+        final CompletableFuture<Void> completedFuture = CompletableFuture.completedFuture(null);
+        doReturn(completedFuture).when(storageService).delete(expectedPath);
+
+        // Try to remove a list.
+        final FirebaseDatabase database = new FirebaseDatabase(storageService);
+        database.removeTodoList(todoListID);
+
+        verify(storageService).delete(expectedPath);
+    }
+
+    @Test
+    public void removeTodoListThrowsDatabaseExceptionOnError() {
+        final UUID todoListID = UUID.randomUUID();
+        final String expectedPath = TODO_LIST_PATH + todoListID.toString() + ".json";
+
+        // Return a future that simulates an error during the deletion.
+        final CompletableFuture<Void> failingFuture = new CompletableFuture<>();
+        failingFuture.completeExceptionally(new RuntimeException());
+        doReturn(failingFuture).when(storageService).delete(expectedPath);
+
+        final FirebaseDatabase database = new FirebaseDatabase(storageService);
+
+        assertThrows(DatabaseException.class, () -> database.removeTodoList(todoListID));
+        verify(storageService).delete(expectedPath);
+    }
+
+    @Test
+    public void getTodoListRejectsNullTodoListID() {
+        assertThrows(NullPointerException.class, () -> {
+            new FirebaseDatabase(storageService).getTodoList(null);
+        });
+    }
+
+    @Test
+    public void getTodoListWorks() throws DatabaseException {
+        final TodoList todoList = new TodoList("My list");
+        final Task FIXTURE_TASK_1 = new Task("Buy bananas");
+        final Task FIXTURE_TASK_2 = new Task("Eat bananas");
+        todoList.addTask(FIXTURE_TASK_1);
+        todoList.addTask(FIXTURE_TASK_2);
+        final String expectedPath = TODO_LIST_PATH + todoList.getId().toString() + ".json";
+        final byte[] serializedList =
+                JSONSerializer.serializeTodoList(todoList).getBytes(StandardCharsets.UTF_8);
+
+        // Return a future like the one that the FirebaseFileStorageService would produce after
+        // successfully downloading the file.
+        final CompletableFuture<byte[]> completedFuture =
+                CompletableFuture.completedFuture(serializedList);
+        doReturn(completedFuture).when(storageService).download(expectedPath);
+
+        // Try to get a valid list.
+        final FirebaseDatabase database = new FirebaseDatabase(storageService);
+        final TodoList fetchedList = database.getTodoList(todoList.getId());
+
+        verify(storageService).download(expectedPath);
+        assertEquals(todoList, fetchedList);
+        assertEquals(todoList.getSize(), fetchedList.getSize());
+        assertEquals(todoList.getDate().getTime(), fetchedList.getDate().getTime());
+        for (int i = 0; i < todoList.getSize(); i++) {
+            assertEquals(todoList.getTask(i), fetchedList.getTask(i));
+        }
+    }
+
+    @Test
+    public void getTodoListThrowsDatabaseExceptionOnError() {
+        final TodoList todoList = new TodoList("My list");
+        final String expectedPath = TODO_LIST_PATH + todoList.getId().toString() + ".json";
+
+        // Return a future that simulates an error during the download.
+        final CompletableFuture<byte[]> failingFuture = new CompletableFuture<>();
+        failingFuture.completeExceptionally(new RuntimeException());
+        doReturn(failingFuture).when(storageService).download(expectedPath);
+
+        // Try to get a valid list.
+        final FirebaseDatabase database = new FirebaseDatabase(storageService);
+
+        assertThrows(DatabaseException.class, () -> database.getTodoList(todoList.getId()));
+        verify(storageService).download(expectedPath);
+    }
+
+    @Test
+    public void putTaskRejectsNullArguments() {
+        assertThrows(NullPointerException.class, () -> {
+            new FirebaseDatabase(storageService).putTask(null, new Task("Some task"));
+        });
+
+        assertThrows(NullPointerException.class, () -> {
+            new FirebaseDatabase(storageService).putTask(UUID.randomUUID(), null);
+        });
+    }
+
+    @Test
+    public void putTaskWorks() throws DatabaseException {
+        final TodoList todoList = new TodoList("My list");
+        final Task FIXTURE_TASK_1 = new Task("Buy bananas");
+        final Task FIXTURE_TASK_2 = new Task("Eat bananas");
+        todoList.addTask(FIXTURE_TASK_1);
+        final String expectedPath = TODO_LIST_PATH + todoList.getId().toString() + ".json";
+
+        // Return a future like the one that the FirebaseFileStorageService would produce after
+        // successfully downloading the file.
+        final byte[] serializedOriginalList =
+                JSONSerializer.serializeTodoList(todoList).getBytes(StandardCharsets.UTF_8);
+        final CompletableFuture<byte[]> completedDownloadFuture =
+                CompletableFuture.completedFuture(serializedOriginalList);
+        doReturn(completedDownloadFuture).when(storageService).download(expectedPath);
+
+        // Return a future like the one that the FirebaseFileStorageService would produce after
+        // successfully uploading the file.
+        final CompletableFuture<String> completedUploadFuture =
+                CompletableFuture.completedFuture(expectedPath);
+        doReturn(completedUploadFuture).when(storageService).upload(any(), eq(expectedPath));
+
+        // Try to put a task in a valid list.
+        final FirebaseDatabase database = new FirebaseDatabase(storageService);
+        database.putTask(todoList.getId(), FIXTURE_TASK_2);
+
+        // Add the new task to the list, to make it look like what we would expect to be stored
+        // in the database.
+        todoList.addTask(FIXTURE_TASK_2);
+        final byte[] serializedNewList =
+                JSONSerializer.serializeTodoList(todoList).getBytes(StandardCharsets.UTF_8);
+
+        verify(storageService).download(expectedPath);
+        verify(storageService).upload(serializedNewList, expectedPath);
+    }
+
+    @Test
+    public void putTaskThrowsDatabaseExceptionOnError() {
+        final TodoList todoList = new TodoList("My list");
+        final Task FIXTURE_TASK_1 = new Task("Buy bananas");
+        final String expectedPath = TODO_LIST_PATH + todoList.getId().toString() + ".json";
+
+        // Return a future that simulates an error during the download.
+        final CompletableFuture<byte[]> failingFuture = new CompletableFuture<>();
+        failingFuture.completeExceptionally(new RuntimeException());
+        doReturn(failingFuture).when(storageService).download(expectedPath);
+
+        // Try to put a task in a valid list.
+        final FirebaseDatabase database = new FirebaseDatabase(storageService);
+
+        assertThrows(
+                DatabaseException.class,
+                () -> database.putTask(todoList.getId(), FIXTURE_TASK_1)
+        );
+        verify(storageService).download(expectedPath);
+    }
+
+    @Test
+    public void removeTaskRejectsNullArguments() {
+        assertThrows(NullPointerException.class, () -> {
+            new FirebaseDatabase(storageService).removeTask(null, 0);
+        });
+
+        assertThrows(NullPointerException.class, () -> {
+            new FirebaseDatabase(storageService).putTask(UUID.randomUUID(), null);
+        });
+    }
+
+    @Test
+    public void removeTaskWorks() throws DatabaseException {
+        final TodoList todoList = new TodoList("My list");
+        final Task FIXTURE_TASK_1 = new Task("Buy bananas");
+        todoList.addTask(FIXTURE_TASK_1);
+        final String expectedPath = TODO_LIST_PATH + todoList.getId().toString() + ".json";
+
+        // Return a future like the one that the FirebaseFileStorageService would produce after
+        // successfully downloading the file.
+        final byte[] serializedOriginalList =
+                JSONSerializer.serializeTodoList(todoList).getBytes(StandardCharsets.UTF_8);
+        final CompletableFuture<byte[]> completedDownloadFuture =
+                CompletableFuture.completedFuture(serializedOriginalList);
+        doReturn(completedDownloadFuture).when(storageService).download(expectedPath);
+
+        // Return a future like the one that the FirebaseFileStorageService would produce after
+        // successfully uploading the file.
+        final CompletableFuture<String> completedUploadFuture =
+                CompletableFuture.completedFuture(expectedPath);
+        doReturn(completedUploadFuture).when(storageService).upload(any(), eq(expectedPath));
+
+        // Try to remove a task from valid list.
+        final FirebaseDatabase database = new FirebaseDatabase(storageService);
+        database.removeTask(todoList.getId(), 0);
+
+        // Remote the task from list, to make it look like what we would expect to be stored
+        // in the database.
+        todoList.removeTask(0);
+        final byte[] serializedNewList =
+                JSONSerializer.serializeTodoList(todoList).getBytes(StandardCharsets.UTF_8);
+
+        verify(storageService).download(expectedPath);
+        verify(storageService).upload(serializedNewList, expectedPath);
+    }
+
+    @Test
+    public void removeTaskThrowDatabaseExceptionOnError() {
+        final TodoList todoList = new TodoList("My list");
+        final String expectedPath = TODO_LIST_PATH + todoList.getId().toString() + ".json";
+
+        // Return a future that simulates an error during the download.
+        final CompletableFuture<byte[]> failingFuture = new CompletableFuture<>();
+        failingFuture.completeExceptionally(new RuntimeException());
+        doReturn(failingFuture).when(storageService).download(expectedPath);
+
+
+        // Try to remove a task from a valid list.
+        final FirebaseDatabase database = new FirebaseDatabase(storageService);
+
+        assertThrows(
+                DatabaseException.class,
+                () -> database.removeTask(todoList.getId(), 0)
+        );
+        verify(storageService).download(expectedPath);
+    }
+
+    @Test
+    public void getTaskRejectsNullArguments() {
+        assertThrows(NullPointerException.class, () -> {
+            new FirebaseDatabase(storageService).getTask(null, 0);
+        });
+
+        assertThrows(NullPointerException.class, () -> {
+            new FirebaseDatabase(storageService).getTask(UUID.randomUUID(), null);
+        });
+    }
+
+    @Test
+    public void getTaskWorks() throws DatabaseException {
+        final TodoList todoList = new TodoList("My list");
+        final Task FIXTURE_TASK_1 = new Task("Buy bananas");
+        final Task FIXTURE_TASK_2 = new Task("Eat bananas");
+        todoList.addTask(FIXTURE_TASK_1);
+        todoList.addTask(FIXTURE_TASK_2);
+        final String expectedPath = TODO_LIST_PATH + todoList.getId().toString() + ".json";
+        final byte[] serializedList =
+                JSONSerializer.serializeTodoList(todoList).getBytes(StandardCharsets.UTF_8);
+
+        // Return a future like the one that the FirebaseFileStorageService would produce after
+        // successfully downloading the file.
+        final CompletableFuture<byte[]> completedFuture =
+                CompletableFuture.completedFuture(serializedList);
+        doReturn(completedFuture).when(storageService).download(expectedPath);
+
+        // Try to get a valid task.
+        final FirebaseDatabase database = new FirebaseDatabase(storageService);
+        final Task fetchedTask = database.getTask(todoList.getId(), 1);
+
+        verify(storageService).download(expectedPath);
+        assertEquals(FIXTURE_TASK_2, fetchedTask);
+    }
+
+    @Test
+    public void getTaskThrowsDatabaseExceptionOnError() {
+        final UUID todoListID = UUID.randomUUID();
+        final String expectedPath = TODO_LIST_PATH + todoListID.toString() + ".json";
+
+        // Return a future that simulates an error during the download.
+        final CompletableFuture<Void> failingFuture = new CompletableFuture<>();
+        failingFuture.completeExceptionally(new RuntimeException());
+        doReturn(failingFuture).when(storageService).download(expectedPath);
+
+        final FirebaseDatabase database = new FirebaseDatabase(storageService);
+
+        assertThrows(DatabaseException.class, () -> database.getTask(todoListID, 0));
+        verify(storageService).download(expectedPath);
+    }
+}

--- a/app/src/test/java/com/github/steroidteam/todolist/database/VolatileDatabaseTest.java
+++ b/app/src/test/java/com/github/steroidteam/todolist/database/VolatileDatabaseTest.java
@@ -1,4 +1,4 @@
-package com.github.steroidteam.todolist;
+package com.github.steroidteam.todolist.database;
 
 import com.github.steroidteam.todolist.database.DatabaseException;
 import com.github.steroidteam.todolist.database.VolatileDatabase;

--- a/app/src/test/java/com/github/steroidteam/todolist/todo/TaskTest.java
+++ b/app/src/test/java/com/github/steroidteam/todolist/todo/TaskTest.java
@@ -1,4 +1,4 @@
-package com.github.steroidteam.todolist;
+package com.github.steroidteam.todolist.todo;
 
 import com.github.steroidteam.todolist.todo.Task;
 

--- a/app/src/test/java/com/github/steroidteam/todolist/todo/TodoListTest.java
+++ b/app/src/test/java/com/github/steroidteam/todolist/todo/TodoListTest.java
@@ -1,4 +1,4 @@
-package com.github.steroidteam.todolist;
+package com.github.steroidteam.todolist.todo;
 
 import com.github.steroidteam.todolist.todo.Task;
 import com.github.steroidteam.todolist.todo.TodoList;

--- a/app/src/test/java/com/github/steroidteam/todolist/util/JSONSerializerTest.java
+++ b/app/src/test/java/com/github/steroidteam/todolist/util/JSONSerializerTest.java
@@ -2,12 +2,11 @@ package com.github.steroidteam.todolist.util;
 
 import com.github.steroidteam.todolist.todo.Task;
 import com.github.steroidteam.todolist.todo.TodoList;
-import com.github.steroidteam.todolist.util.JSONSerializer;
 import com.google.gson.JsonSyntaxException;
 
 import org.junit.Test;
 
-import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.UUID;
 
@@ -15,6 +14,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 public class JSONSerializerTest {
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+
     @Test
     public void todoListSerializerRejectsNull() {
         assertThrows(NullPointerException.class, () -> {
@@ -34,8 +35,7 @@ public class JSONSerializerTest {
         final String LIST_TITLE = "Test list";
 
         final TodoList todoList = new TodoList(LIST_TITLE);
-        final String expectedFormattedDate = DateFormat.getDateTimeInstance(DateFormat.FULL,
-                DateFormat.FULL).format(todoList.getDate());
+        final String expectedFormattedDate = DATE_FORMAT.format(todoList.getDate());
 
         final String actualSerializedObject = JSONSerializer.serializeTodoList(todoList);
         final String expectedSerializedObject = "{" +
@@ -56,8 +56,7 @@ public class JSONSerializerTest {
         final TodoList todoList = new TodoList(LIST_TITLE);
         todoList.addTask(new Task(TASK1_DESC));
         todoList.addTask(new Task(TASK2_DESC));
-        final String expectedFormattedDate = DateFormat.getDateTimeInstance(DateFormat.FULL,
-                DateFormat.FULL).format(todoList.getDate());
+        final String expectedFormattedDate = DATE_FORMAT.format(todoList.getDate());
 
         final String actualSerializedObject = JSONSerializer.serializeTodoList(todoList);
         final String expectedSerializedObject = "{" +
@@ -73,9 +72,7 @@ public class JSONSerializerTest {
     public void todoListDeserializerWorksWithEmptyTasks() {
         final UUID FIXTURE_UUID = UUID.randomUUID();
         final String FIXTURE_TITLE = "Test list";
-        final DateFormat FIXTURE_DATE_FORMAT = DateFormat.getDateTimeInstance(DateFormat.FULL,
-                DateFormat.FULL);
-        final String FIXTURE_FORMATTED_DATE = FIXTURE_DATE_FORMAT.format(new Date());
+        final String FIXTURE_FORMATTED_DATE = DATE_FORMAT.format(new Date());
 
         final String FIXTURE_JSON = "{" +
                 "\"id\":\"" + FIXTURE_UUID.toString() + "\"," +
@@ -88,7 +85,7 @@ public class JSONSerializerTest {
         assertEquals(actualDeserializedObject.getId(), FIXTURE_UUID);
         assertEquals(actualDeserializedObject.getSize(), 0);
         assertEquals(actualDeserializedObject.getTitle(), FIXTURE_TITLE);
-        assertEquals(FIXTURE_DATE_FORMAT.format(actualDeserializedObject.getDate()), FIXTURE_FORMATTED_DATE);
+        assertEquals(DATE_FORMAT.format(actualDeserializedObject.getDate()), FIXTURE_FORMATTED_DATE);
     }
 
     @Test
@@ -97,9 +94,7 @@ public class JSONSerializerTest {
         final String FIXTURE_TITLE = "Test list";
         final String TASK1_DESC = "Buy bananas";
         final String TASK2_DESC = "Eat fruit";
-        final DateFormat FIXTURE_DATE_FORMAT = DateFormat.getDateTimeInstance(DateFormat.FULL,
-                DateFormat.FULL);
-        final String FIXTURE_FORMATTED_DATE = FIXTURE_DATE_FORMAT.format(new Date());
+        final String FIXTURE_FORMATTED_DATE = DATE_FORMAT.format(new Date());
 
         final String FIXTURE_JSON = "{" +
                 "\"id\":\"" + FIXTURE_UUID.toString() + "\"," +
@@ -114,7 +109,7 @@ public class JSONSerializerTest {
         assertEquals(actualDeserializedObject.getTask(0), new Task(TASK1_DESC));
         assertEquals(actualDeserializedObject.getTask(1), new Task(TASK2_DESC));
         assertEquals(actualDeserializedObject.getTitle(), FIXTURE_TITLE);
-        assertEquals(FIXTURE_DATE_FORMAT.format(actualDeserializedObject.getDate()), FIXTURE_FORMATTED_DATE);
+        assertEquals(DATE_FORMAT.format(actualDeserializedObject.getDate()), FIXTURE_FORMATTED_DATE);
     }
 
     @Test

--- a/app/src/test/java/com/github/steroidteam/todolist/util/JSONSerializerTest.java
+++ b/app/src/test/java/com/github/steroidteam/todolist/util/JSONSerializerTest.java
@@ -1,4 +1,4 @@
-package com.github.steroidteam.todolist;
+package com.github.steroidteam.todolist.util;
 
 import com.github.steroidteam.todolist.todo.Task;
 import com.github.steroidteam.todolist.todo.TodoList;


### PR DESCRIPTION
This acts as part II of the work started in #45, by adding an extra layer on top of the `FirebaseFileStorageService` that adapts its API to the `Database`.

It is important to note that the current calls are blocking (i.e. the main thread waits until the operation is fulfilled), which is clearly suboptimal but should be fine for now.
