### PR TITLE
fix/ItemViewActivityTest ?

### DIFF
--- a/app/src/androidTest/java/com/github/steroidteam/todolist/ItemViewActivityTest.java
+++ b/app/src/androidTest/java/com/github/steroidteam/todolist/ItemViewActivityTest.java
@@ -5,7 +5,9 @@ import android.content.Intent;
 import android.os.IBinder;
 import android.view.View;
 import android.view.WindowManager;
+import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
@@ -17,8 +19,6 @@ import androidx.test.espresso.matcher.BoundedMatcher;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
-
-import com.github.steroidteam.todolist.util.TodoAdapter;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -35,11 +35,9 @@ import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.longClick;
 import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.contrib.RecyclerViewActions.actionOnItem;
 import static androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition;
-import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.withChild;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
@@ -109,12 +107,12 @@ public class ItemViewActivityTest {
             // Try to remove the first task
             onView(withId(R.id.activity_itemview_itemlist)).perform(actionOnItemAtPosition(0, longClick()));
 
-            onView(withText("You are about to delete a task!")).check(matches(isDisplayed()));
+            onView(withText("You are about to delete a task!")).inRoot(isDialog()).check(matches(isDisplayed()));
 
-            onView(withText("Yes")).perform(click());
+            onView(withText("Yes")).inRoot(isDialog()).perform(click());
 
             //after deleting the first item we check that we have the second one at position 0.
-            onView(withId(R.id.layout_task_body)).check(matches(withText(TASK_DESCRIPTION_2)));
+            onView(withId(R.id.activity_itemview_itemlist)).check(matches(atPositionCheckText(0, TASK_DESCRIPTION_2)));
         }
     }
 
@@ -144,28 +142,89 @@ public class ItemViewActivityTest {
             openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getInstrumentation().getTargetContext());
             onView(withText("Delete")).perform(click());
 
-            openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getInstrumentation().getTargetContext());
-            onView(withText("Delete")).perform(click());
-
-            openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getInstrumentation().getTargetContext());
-            onView(withText("Delete")).perform(click());
-            
             onView(withId(R.id.activity_itemview_itemlist)).perform(
                     RecyclerViewActions.actionOnItemAtPosition(0, MyViewAction.clickChildViewWithId(R.id.layout_task_delete_button)));
 
-            onView(withText("You are about to delete a task!")).check(matches(isDisplayed()));
+            onView(withText("You are about to delete a task!")).inRoot(isDialog()).check(matches(isDisplayed()));
 
-            onView(withText("Yes")).perform(click());
+            onView(withText("Yes")).inRoot(isDialog()).perform(click());
 
             //after deleting the first item we check that we have the second one at position 0.
-            onView(withId(R.id.layout_task_body)).check(matches(withText(TASK_DESCRIPTION_2)));
+            onView(withId(R.id.activity_itemview_itemlist)).check(matches(atPositionCheckText(0, TASK_DESCRIPTION_2)));
 
             //check that cancel the deletion works
             onView(withId(R.id.activity_itemview_itemlist)).perform(
                     RecyclerViewActions.actionOnItemAtPosition(0, MyViewAction.clickChildViewWithId(R.id.layout_task_delete_button)));
-            onView(withText("No")).perform(click());
-            onView(withId(R.id.layout_task_body)).check(matches(withText(TASK_DESCRIPTION_2)));
+
+            onView(withText("No")).inRoot(isDialog()).perform(click());
+
+            onView(withId(R.id.activity_itemview_itemlist)).check(matches(atPositionCheckText(0, TASK_DESCRIPTION_2)));
         }
+    }
+
+    @Test
+    public void confirmDeletionWorks() {
+        Intent itemViewActivity = new Intent(ApplicationProvider.getApplicationContext(), ItemViewActivity.class);
+
+        try (ActivityScenario<ItemViewActivity> scenario = ActivityScenario.launch(itemViewActivity)) {
+
+            final String TASK_DESCRIPTION = "Buy bananas";
+
+            // Type a task description in the "new task" text field.
+            onView(withId(R.id.new_task_text))
+                    .perform(typeText(TASK_DESCRIPTION), closeSoftKeyboard());
+
+            // Hit the button to create a new task.
+            onView(withId(R.id.new_task_btn))
+                    .perform(click());
+
+            onView(withId(R.id.activity_itemview_itemlist)).perform(actionOnItemAtPosition(0, longClick()));
+
+            onView(withText("You are about to delete a task!")).inRoot(isDialog()).check(matches(isDisplayed()));
+
+            onView(withText("No")).inRoot(isDialog()).perform(click());
+
+            onView(withId(R.id.activity_itemview_itemlist)).check(matches(atPositionCheckText(0, TASK_DESCRIPTION)));
+        }
+    }
+
+    @Test
+    public void notificationDeleteWorks() {
+        Intent itemViewActivity = new Intent(ApplicationProvider.getApplicationContext(), ItemViewActivity.class);
+
+        try (ActivityScenario<ItemViewActivity> scenario = ActivityScenario.launch(itemViewActivity)) {
+            final String TASK_DESCRIPTION = "Buy bananas";
+            // Type a task description in the "new task" text field.
+            onView(withId(R.id.new_task_text))
+                    .perform(typeText(TASK_DESCRIPTION), closeSoftKeyboard());
+
+            // Hit the button to create a new task.
+            onView(withId(R.id.new_task_btn))
+                    .perform(click());
+
+            onView(withId(R.id.activity_itemview_itemlist)).perform(actionOnItemAtPosition(0, longClick()));
+
+            onView(withText("You are about to delete a task!")).inRoot(isDialog()).check(matches(isDisplayed()));
+
+            onView(withText("Yes")).inRoot(isDialog()).perform(click());
+
+            onView(withText("Successfully removed the task !")).inRoot(new ToastMatcher()).check(matches(isDisplayed()));
+        }
+    }
+    public static Matcher<View> atPositionCheckText(final int position, @NonNull final String expectedText) {
+        return new BoundedMatcher<View, RecyclerView>(RecyclerView.class) {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("View holder at position " + String.valueOf(position) + " ");
+            }
+
+            @Override
+            protected boolean matchesSafely(final RecyclerView view) {
+                View taskView = view.getChildAt(position);
+                TextView bodyView = taskView.findViewById(R.id.layout_task_body);
+                return bodyView.getText().toString().equals(expectedText);
+            }
+        };
     }
 
     // Simple ViewAction to click on the button within a item of the recyclerView
@@ -192,58 +251,7 @@ public class ItemViewActivityTest {
         }
     }
 
-    @Test
-    public void confirmDeletionWorks() {
-        Intent itemViewActivity = new Intent(ApplicationProvider.getApplicationContext(), ItemViewActivity.class);
-
-        try (ActivityScenario<ItemViewActivity> scenario = ActivityScenario.launch(itemViewActivity)) {
-
-            final String TASK_DESCRIPTION = "Buy bananas";
-
-            // Type a task description in the "new task" text field.
-            onView(withId(R.id.new_task_text))
-                    .perform(typeText(TASK_DESCRIPTION), closeSoftKeyboard());
-
-            // Hit the button to create a new task.
-            onView(withId(R.id.new_task_btn))
-                    .perform(click());
-
-            onView(withId(R.id.activity_itemview_itemlist)).perform(actionOnItemAtPosition(0, longClick()));
-
-            onView(withText("You are about to delete a task!")).check(matches(isDisplayed()));
-
-            onView(withText("No")).perform(click());
-
-            onView(withId(R.id.layout_task_body)).check(matches(withText(TASK_DESCRIPTION)));
-        }
-    }
-
-    @Test
-    public void notificationDeleteWorks() {
-        Intent itemViewActivity = new Intent(ApplicationProvider.getApplicationContext(), ItemViewActivity.class);
-
-        try (ActivityScenario<ItemViewActivity> scenario = ActivityScenario.launch(itemViewActivity)) {
-            final String TASK_DESCRIPTION = "Buy bananas";
-            // Type a task description in the "new task" text field.
-            onView(withId(R.id.new_task_text))
-                    .perform(typeText(TASK_DESCRIPTION), closeSoftKeyboard());
-
-            // Hit the button to create a new task.
-            onView(withId(R.id.new_task_btn))
-                    .perform(click());
-
-            onView(withId(R.id.activity_itemview_itemlist)).perform(actionOnItemAtPosition(0, longClick()));
-
-            onView(withText("You are about to delete a task!")).check(matches(isDisplayed()));
-
-            onView(withText("Yes")).perform(click());
-
-            onView(withText("Successfully removed the task !")).inRoot(new ToastMatcher()).check(matches(isDisplayed()));
-        }
-    }
-
-
-    public class ToastMatcher extends TypeSafeMatcher<Root> {
+    public static class ToastMatcher extends TypeSafeMatcher<Root> {
 
         @Override
         public void describeTo(Description description) {

--- a/app/src/androidTest/java/com/github/steroidteam/todolist/ItemViewActivityTest.java
+++ b/app/src/androidTest/java/com/github/steroidteam/todolist/ItemViewActivityTest.java
@@ -3,7 +3,6 @@ package com.github.steroidteam.todolist;
 
 import android.content.Intent;
 import android.os.IBinder;
-import android.os.SystemClock;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.TextView;
@@ -34,7 +33,6 @@ import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.longClick;
-import static androidx.test.espresso.action.ViewActions.pressBack;
 import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition;

--- a/app/src/androidTest/java/com/github/steroidteam/todolist/ItemViewActivityTest.java
+++ b/app/src/androidTest/java/com/github/steroidteam/todolist/ItemViewActivityTest.java
@@ -3,6 +3,7 @@ package com.github.steroidteam.todolist;
 
 import android.content.Intent;
 import android.os.IBinder;
+import android.os.SystemClock;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.TextView;
@@ -33,6 +34,7 @@ import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.longClick;
+import static androidx.test.espresso.action.ViewActions.pressBack;
 import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition;
@@ -109,7 +111,7 @@ public class ItemViewActivityTest {
 
             onView(withText("You are about to delete a task!")).inRoot(isDialog()).check(matches(isDisplayed()));
 
-            onView(withText("Yes")).inRoot(isDialog()).perform(click());
+            onView(withId(android.R.id.button1)).inRoot(isDialog()).perform(click());
 
             //after deleting the first item we check that we have the second one at position 0.
             onView(withId(R.id.activity_itemview_itemlist)).check(matches(atPositionCheckText(0, TASK_DESCRIPTION_2)));
@@ -147,16 +149,7 @@ public class ItemViewActivityTest {
 
             onView(withText("You are about to delete a task!")).inRoot(isDialog()).check(matches(isDisplayed()));
 
-            onView(withText("Yes")).inRoot(isDialog()).perform(click());
-
-            //after deleting the first item we check that we have the second one at position 0.
-            onView(withId(R.id.activity_itemview_itemlist)).check(matches(atPositionCheckText(0, TASK_DESCRIPTION_2)));
-
-            //check that cancel the deletion works
-            onView(withId(R.id.activity_itemview_itemlist)).perform(
-                    RecyclerViewActions.actionOnItemAtPosition(0, MyViewAction.clickChildViewWithId(R.id.layout_task_delete_button)));
-
-            onView(withText("No")).inRoot(isDialog()).perform(click());
+            onView(withId(android.R.id.button1)).inRoot(isDialog()).perform(click());
 
             onView(withId(R.id.activity_itemview_itemlist)).check(matches(atPositionCheckText(0, TASK_DESCRIPTION_2)));
         }
@@ -264,9 +257,7 @@ public class ItemViewActivityTest {
             if (type == WindowManager.LayoutParams.TYPE_TOAST) {
                 IBinder windowToken = root.getDecorView().getWindowToken();
                 IBinder appToken = root.getDecorView().getApplicationWindowToken();
-                if (windowToken == appToken) {
-                    return true;
-                }
+                return windowToken == appToken;
             }
             return false;
         }

--- a/app/src/androidTest/java/com/github/steroidteam/todolist/ItemViewActivityTest.java
+++ b/app/src/androidTest/java/com/github/steroidteam/todolist/ItemViewActivityTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static androidx.test.espresso.Espresso.openContextualActionModeOverflowMenu;
 import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
@@ -139,7 +139,7 @@ public class ItemViewActivityTest {
             onView(withId(R.id.new_task_btn))
                     .perform(click());
 
-            openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getInstrumentation().getTargetContext());
+            openContextualActionModeOverflowMenu();
             onView(withText("Delete")).perform(click());
 
             onView(withId(R.id.activity_itemview_itemlist)).perform(
@@ -147,7 +147,7 @@ public class ItemViewActivityTest {
 
             onView(withText("You are about to delete a task!")).inRoot(isDialog()).check(matches(isDisplayed()));
 
-            onView(withId(android.R.id.button1)).inRoot(isDialog()).perform(click());
+            onView(withText("Yes")).inRoot(isDialog()).perform(click());
 
             onView(withId(R.id.activity_itemview_itemlist)).check(matches(atPositionCheckText(0, TASK_DESCRIPTION_2)));
         }


### PR DESCRIPTION
Hey!

I tried to fix the item activity test which was failing. 
I think the failure is caused by the alert dialog not closing. Sometimes the alert dialog is not closing "faster enough" and so the onView in the next line is not able to recover other layout ids.
I ran multiples times locally and the test was failing some times but after the fix, I didn't get any failure, so maybe it is okay now.

I cleaned up also some tests.
