### PR TITLE
feature: Allow setting task due dates via NLP

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,6 +105,9 @@ dependencies {
     implementation 'com.larswerkman:HoloColorPicker:1.5'
 
     androidTestImplementation 'androidx.test.espresso:espresso-web:3.3.0'
+
+    // Natural language date parsing
+    implementation group: 'org.ocpsoft.prettytime', name: 'prettytime-nlp', version: '5.0.1.Final'
 }
 
 tasks.withType(Test) {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,5 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep class org.ocpsoft.prettytime.i18n**

--- a/app/src/androidTest/java/com/github/steroidteam/todolist/AudioRecorderFragmentTest.java
+++ b/app/src/androidTest/java/com/github/steroidteam/todolist/AudioRecorderFragmentTest.java
@@ -7,15 +7,21 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
+import android.Manifest;
 import androidx.fragment.app.testing.FragmentScenario;
+import androidx.test.rule.GrantPermissionRule;
 import com.github.steroidteam.todolist.view.AudioRecorderFragment;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AudioRecorderFragmentTest {
+    @Rule
+    public GrantPermissionRule permissionRule =
+            GrantPermissionRule.grant(Manifest.permission.RECORD_AUDIO);
 
     @Before
     public void init() {

--- a/app/src/androidTest/java/com/github/steroidteam/todolist/MapFragmentTest.java
+++ b/app/src/androidTest/java/com/github/steroidteam/todolist/MapFragmentTest.java
@@ -11,11 +11,13 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static org.junit.Assert.assertEquals;
 
+import android.Manifest;
 import android.view.KeyEvent;
 import androidx.fragment.app.testing.FragmentScenario;
 import androidx.lifecycle.Lifecycle;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.GrantPermissionRule;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
@@ -30,6 +32,13 @@ import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class MapFragmentTest {
+    @Rule
+    public GrantPermissionRule coarseLocationPermissionRule =
+            GrantPermissionRule.grant(Manifest.permission.ACCESS_COARSE_LOCATION);
+
+    @Rule
+    public GrantPermissionRule fineLocationPermissionRule =
+            GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION);
 
     @Rule
     public ActivityScenarioRule<MainActivity> activityRule =

--- a/app/src/main/java/com/github/steroidteam/todolist/database/Database.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/database/Database.java
@@ -68,15 +68,16 @@ public interface Database {
     CompletableFuture<TodoList> removeTask(UUID todoListID, Integer taskIndex);
 
     /**
-     * Renames a task in the database.
+     * Updates a task in the database.
      *
      * @param todoListID The id of the associated list of the task.
      * @param taskIndex The index of the task within the list.
+     * @param newTask The new task.
      */
-    CompletableFuture<Task> renameTask(UUID todoListID, Integer taskIndex, String newName);
+    CompletableFuture<Task> updateTask(UUID todoListID, Integer taskIndex, Task newTask);
 
     /**
-     * Gets the task from the database
+     * Gets the task from the database.
      *
      * @param todoListID The id of the associated list of the task.
      * @param taskIndex The index of the task you want from a to-do list.

--- a/app/src/main/java/com/github/steroidteam/todolist/database/FirebaseDatabase.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/database/FirebaseDatabase.java
@@ -138,7 +138,7 @@ public class FirebaseDatabase implements Database {
     }
 
     @Override
-    public CompletableFuture<Task> renameTask(UUID todoListID, Integer taskIndex, String newName) {
+    public CompletableFuture<Task> updateTask(UUID todoListID, Integer taskIndex, Task newTask) {
         Objects.requireNonNull(todoListID);
         Objects.requireNonNull(taskIndex);
         String listPath = TODO_LIST_PATH + todoListID.toString() + ".json";
@@ -148,7 +148,7 @@ public class FirebaseDatabase implements Database {
                 // Remove the task from the object.
                 .thenApply(
                         todoList -> {
-                            todoList.renameTask(taskIndex, newName);
+                            todoList.updateTask(taskIndex, newTask);
                             return todoList;
                         })
                 // Re-serialize and upload the new object.

--- a/app/src/main/java/com/github/steroidteam/todolist/model/TodoRepository.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/model/TodoRepository.java
@@ -6,6 +6,7 @@ import com.github.steroidteam.todolist.database.Database;
 import com.github.steroidteam.todolist.database.DatabaseFactory;
 import com.github.steroidteam.todolist.model.todo.Task;
 import com.github.steroidteam.todolist.model.todo.TodoList;
+import java.util.Date;
 import java.util.UUID;
 
 public class TodoRepository {
@@ -42,14 +43,24 @@ public class TodoRepository {
 
     public void renameTask(int index, String newText) {
         this.database
-                .renameTask(todoListID, index, newText)
+                .getTask(todoListID, index)
+                .thenCompose(
+                        task -> {
+                            task.setBody(newText);
+                            return this.database.updateTask(todoListID, index, task);
+                        })
                 .thenCompose(task -> this.database.getTodoList(todoListID))
                 .thenAccept(this.oneTodoList::setValue);
     }
 
     public void setTaskDone(int index, boolean isDone) {
         this.database
-                .setTaskDone(todoListID, index, isDone)
+                .getTask(todoListID, index)
+                .thenCompose(
+                        task -> {
+                            task.setDone(isDone);
+                            return this.database.updateTask(todoListID, index, task);
+                        })
                 .thenCompose(task -> this.database.getTodoList(todoListID))
                 .thenAccept(this.oneTodoList::setValue);
     }

--- a/app/src/main/java/com/github/steroidteam/todolist/model/TodoRepository.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/model/TodoRepository.java
@@ -64,4 +64,17 @@ public class TodoRepository {
                 .thenCompose(task -> this.database.getTodoList(todoListID))
                 .thenAccept(this.oneTodoList::setValue);
     }
+
+    public void setTaskDueDate(int index, Date dueDate) {
+        this.database
+                .getTask(todoListID, index)
+                .thenCompose(
+                        task -> {
+                            task.setDueDate(dueDate);
+                            return this.database.updateTask(todoListID, index, task);
+                        })
+                .thenCompose(task -> this.database.getTodoList(todoListID))
+                .thenAccept(this.oneTodoList::setValue);
+        this.database.getTodoList(todoListID).thenAccept(this.oneTodoList::setValue);
+    }
 }

--- a/app/src/main/java/com/github/steroidteam/todolist/model/todo/TodoList.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/model/todo/TodoList.java
@@ -56,11 +56,8 @@ public class TodoList {
         }
     }
 
-    public void renameTask(int index, String newBody) {
-        Task task = list.get(index);
-        if (task != null) {
-            task.setBody(newBody);
-        }
+    public void updateTask(int index, Task task) {
+        list.set(index, task);
     }
 
     public int getSize() {
@@ -86,10 +83,6 @@ public class TodoList {
     public TodoList setTitle(String newTitle) {
         this.title = newTitle;
         return this;
-    }
-
-    public List<Task> getImportantTask() {
-        return list;
     }
 
     @Override

--- a/app/src/main/java/com/github/steroidteam/todolist/view/ItemViewFragment.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/view/ItemViewFragment.java
@@ -123,7 +123,7 @@ public class ItemViewFragment extends Fragment {
                 (v) -> {
                     closeUpdateLayout(v);
                     itemViewModel.renameTask(position, userInputBody.getText().toString());
-                    itemViewModel.setTaskDone(position, taskCheckedBox.isChecked());
+                    itemViewModel.setTaskDueDate(position, taskCheckedBox.isChecked());
                 });
 
         Button deleteButton = getView().findViewById(R.id.layout_update_task_delete);

--- a/app/src/main/java/com/github/steroidteam/todolist/view/ListSelectionFragment.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/view/ListSelectionFragment.java
@@ -18,6 +18,7 @@ import com.github.steroidteam.todolist.view.adapter.TodoArrayListAdapter;
 import com.github.steroidteam.todolist.view.dialog.DialogListener;
 import com.github.steroidteam.todolist.view.dialog.InputDialogFragment;
 import com.github.steroidteam.todolist.view.dialog.SimpleDialogFragment;
+import com.github.steroidteam.todolist.view.misc.TodoTouchHelper;
 import com.github.steroidteam.todolist.viewmodel.ListSelectionViewModel;
 import java.util.UUID;
 

--- a/app/src/main/java/com/github/steroidteam/todolist/view/misc/DateHighlighterTextWatcher.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/view/misc/DateHighlighterTextWatcher.java
@@ -1,0 +1,58 @@
+package com.github.steroidteam.todolist.view.misc;
+
+import android.content.Context;
+import android.text.Editable;
+import android.text.Spannable;
+import android.text.TextWatcher;
+import java.util.List;
+import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
+import org.ocpsoft.prettytime.nlp.parse.DateGroup;
+
+public class DateHighlighterTextWatcher implements TextWatcher {
+    private final PrettyTimeParser timeParser;
+    private final Context context;
+
+    public DateHighlighterTextWatcher(Context context, PrettyTimeParser timeParser) {
+        this.context = context;
+        this.timeParser = timeParser;
+    }
+
+    @Override
+    public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
+
+    @Override
+    public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
+
+    @Override
+    public void afterTextChanged(Editable editable) {
+        List<DateGroup> parsedDates = timeParser.parseSyntax(editable.toString());
+
+        // Remove any potentially existing spans (just in case a date was recognized before while
+        // typing). We don't use editable.clearSpans(), as it makes the text field behave
+        // unexpectedly.
+        for (DueDateInputSpan span :
+                editable.getSpans(0, editable.length(), DueDateInputSpan.class)) {
+            editable.removeSpan(span);
+        }
+
+        // The parser tends to identify isolated numbers (like "1" or "23") as times. To avoid
+        // sentences like "Buy 3 avocados" to be matched, we simply remove those cases.
+        // This does not break cases like "Buy 3 avocados at 12", since the time is parsed as "at
+        // 12".
+        for (DateGroup dg : parsedDates) {
+            if (dg.getText().matches("\\d{1,2}")) parsedDates.remove(dg);
+        }
+
+        if (parsedDates.size() == 0) return;
+
+        // Multiple dates might appear in the text. We assume that the target one is the last one.
+        DateGroup lastDate = parsedDates.get(parsedDates.size() - 1);
+
+        int startPosition = lastDate.getPosition() - 1;
+        editable.setSpan(
+                new DueDateInputSpan(context, lastDate.getDates().get(0)),
+                startPosition,
+                startPosition + lastDate.getText().length(),
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+    }
+}

--- a/app/src/main/java/com/github/steroidteam/todolist/view/misc/DueDateInputSpan.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/view/misc/DueDateInputSpan.java
@@ -1,0 +1,20 @@
+package com.github.steroidteam.todolist.view.misc;
+
+import android.content.Context;
+import android.text.style.ForegroundColorSpan;
+import androidx.core.content.ContextCompat;
+import com.github.steroidteam.todolist.R;
+import java.util.Date;
+
+public class DueDateInputSpan extends ForegroundColorSpan {
+    private final Date date;
+
+    public DueDateInputSpan(Context context, Date date) {
+        super(ContextCompat.getColor(context, R.color.dark_blue));
+        this.date = date;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+}

--- a/app/src/main/java/com/github/steroidteam/todolist/view/misc/TodoTouchHelper.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/view/misc/TodoTouchHelper.java
@@ -1,4 +1,4 @@
-package com.github.steroidteam.todolist.view;
+package com.github.steroidteam.todolist.view.misc;
 
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -10,6 +10,7 @@ import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
 import com.github.steroidteam.todolist.R;
+import com.github.steroidteam.todolist.view.ListSelectionFragment;
 import com.github.steroidteam.todolist.view.adapter.TodoArrayListAdapter;
 
 public class TodoTouchHelper extends ItemTouchHelper.SimpleCallback {

--- a/app/src/main/java/com/github/steroidteam/todolist/viewmodel/ItemViewModel.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/viewmodel/ItemViewModel.java
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel;
 import com.github.steroidteam.todolist.model.TodoRepository;
 import com.github.steroidteam.todolist.model.todo.Task;
 import com.github.steroidteam.todolist.model.todo.TodoList;
+import java.util.Date;
 
 public class ItemViewModel extends ViewModel {
 
@@ -22,8 +23,8 @@ public class ItemViewModel extends ViewModel {
         return this.todoList;
     }
 
-    public void addTask(String body) {
-        repository.putTask(new Task(body));
+    public void addTask(Task task) {
+        repository.putTask(task);
     }
 
     public void removeTask(int index) {
@@ -38,5 +39,9 @@ public class ItemViewModel extends ViewModel {
 
     public void setTaskDone(int index, boolean isDone) {
         repository.setTaskDone(index, isDone);
+    }
+
+    public void setTaskDueDate(int index, Date date) {
+        repository.setTaskDueDate(index, date);
     }
 }

--- a/app/src/test/java/com/github/steroidteam/todolist/database/FirebaseDatabaseTest.java
+++ b/app/src/test/java/com/github/steroidteam/todolist/database/FirebaseDatabaseTest.java
@@ -299,31 +299,6 @@ public class FirebaseDatabaseTest {
     }
 
     @Test
-    public void renameTaskWorks() {
-        TodoList expectedTodoList = new TodoList("some random title");
-        Task task1 = new Task("Task 1");
-        Task task2 = new Task("renamed task 2");
-        expectedTodoList.addTask(task1);
-        expectedTodoList.addTask(task2);
-
-        byte[] serializedTodoList =
-                JSONSerializer.serializeTodoList(expectedTodoList).getBytes(StandardCharsets.UTF_8);
-        downloadFuture.complete(serializedTodoList);
-
-        uploadFuture.complete("Some file path");
-
-        doReturn(downloadFuture).when(storageServiceMock).download(anyString());
-        doReturn(uploadFuture).when(storageServiceMock).upload(any(byte[].class), anyString());
-
-        try {
-            Task task = database.renameTask(UUID.randomUUID(), 1, "renamed task 2").join();
-            assertEquals(task2, task);
-        } catch (Exception e) {
-            fail();
-        }
-    }
-
-    @Test
     public void getNoteWorks() {
         Note expectedNote = new Note("Some random title");
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath "com.google.gms:google-services:4.3.5"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip


### PR DESCRIPTION
This PR includes a feature that allows the user to set a reminder for a task
just by stating it in the task's body.

The text with the date/time will be automatically removed and included in the
`Task`.

Displaying and modifying the due date will come later on, in a separate PR.
