### PR TITLE
feature: Implement dark theme & polish UI

### DIFF
--- a/app/src/androidTest/java/com/github/steroidteam/todolist/AudioRecorderFragmentTest.java
+++ b/app/src/androidTest/java/com/github/steroidteam/todolist/AudioRecorderFragmentTest.java
@@ -60,7 +60,7 @@ public class AudioRecorderFragmentTest {
         bundle.putString(NoteSelectionFragment.NOTE_ID_KEY, UUID.randomUUID().toString());
         FragmentScenario<AudioRecorderFragment> scenario =
                 FragmentScenario.launchInContainer(
-                        AudioRecorderFragment.class, bundle, R.style.Theme_Asteroid);
+                        AudioRecorderFragment.class, bundle, R.style.AsteroidTheme);
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/steroidteam/todolist/DrawingFragmentTest.java
+++ b/app/src/androidTest/java/com/github/steroidteam/todolist/DrawingFragmentTest.java
@@ -73,7 +73,7 @@ public class DrawingFragmentTest {
         UserFactory.set(mockedUser);
         scenario =
                 FragmentScenario.launchInContainer(
-                        DrawingFragment.class, null, R.style.Theme_Asteroid);
+                        DrawingFragment.class, null, R.style.AsteroidTheme);
         CompletableFuture<TodoListCollection> todoListCollectionFuture = new CompletableFuture<>();
         todoListCollectionFuture.complete(new TodoListCollection());
         doReturn(todoListCollectionFuture).when(databaseMock).getTodoListCollection();

--- a/app/src/androidTest/java/com/github/steroidteam/todolist/ItemViewFragmentTest.java
+++ b/app/src/androidTest/java/com/github/steroidteam/todolist/ItemViewFragmentTest.java
@@ -8,9 +8,9 @@ import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
+import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
-import static androidx.test.espresso.matcher.ViewMatchers.withParent;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.github.steroidteam.todolist.CustomMatchers.atPositionCheckBox;
 import static com.github.steroidteam.todolist.CustomMatchers.atPositionCheckText;
@@ -198,7 +198,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
@@ -210,7 +210,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .check(matches(atPositionCheckText(0, TASK_DESCRIPTION, TASK_BODY_LAYOUT_ID)));
@@ -218,7 +218,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .check(matches(atPositionCheckBox(0, false, TASK_BOX_LAYOUT_ID)));
@@ -351,7 +351,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .perform(
@@ -361,7 +361,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
@@ -396,7 +396,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .check(matches(atPositionCheckText(0, TASK_DESCRIPTION_2, TASK_BODY_LAYOUT_ID)));
@@ -404,7 +404,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .check(matches(atPositionCheckBox(0, false, TASK_BOX_LAYOUT_ID)));
@@ -449,7 +449,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .perform(
@@ -458,7 +458,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .perform(
@@ -469,7 +469,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .check(matches(atPositionCheckText(0, TASK_DESCRIPTION_2, TASK_BODY_LAYOUT_ID)));
@@ -501,7 +501,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
@@ -513,7 +513,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .check(matches(atPositionCheckText(0, TASK_DESCRIPTION_2, TASK_BODY_LAYOUT_ID)));
@@ -521,7 +521,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .check(matches(atPositionCheckBox(0, false, TASK_BOX_LAYOUT_ID)));
@@ -573,7 +573,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .perform(
@@ -594,7 +594,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .check(matches(atPositionCheckText(0, TASK_DESCRIPTION_2, TASK_BODY_LAYOUT_ID)));
@@ -627,7 +627,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
@@ -677,7 +677,7 @@ public class ItemViewFragmentTest {
         onView(
                         allOf(
                                 withId(R.id.child_task_recycler_view),
-                                withParent(
+                                isDescendantOfA(
                                         new RecyclerViewMatcher(R.id.activity_itemview_itemlist)
                                                 .atPosition(0))))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));

--- a/app/src/androidTest/java/com/github/steroidteam/todolist/ItemViewFragmentTest.java
+++ b/app/src/androidTest/java/com/github/steroidteam/todolist/ItemViewFragmentTest.java
@@ -136,7 +136,7 @@ public class ItemViewFragmentTest {
         ViewModelFactoryInjection.setCustomTodoListRepo(context, UUID.randomUUID());
         scenario =
                 FragmentScenario.launchInContainer(
-                        ItemViewFragment.class, null, R.style.Theme_Asteroid);
+                        ItemViewFragment.class, null, R.style.AsteroidTheme);
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/steroidteam/todolist/ListSelectionFragmentTest.java
+++ b/app/src/androidTest/java/com/github/steroidteam/todolist/ListSelectionFragmentTest.java
@@ -87,7 +87,7 @@ public class ListSelectionFragmentTest {
 
         scenario =
                 FragmentScenario.launchInContainer(
-                        ListSelectionFragment.class, null, R.style.Theme_Asteroid);
+                        ListSelectionFragment.class, null, R.style.AsteroidTheme);
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/steroidteam/todolist/MapFragmentTest.java
+++ b/app/src/androidTest/java/com/github/steroidteam/todolist/MapFragmentTest.java
@@ -52,7 +52,7 @@ public class MapFragmentTest {
         FirebaseUser mockedUser = Mockito.mock(FirebaseUser.class);
         UserFactory.set(mockedUser);
         scenario =
-                FragmentScenario.launchInContainer(MapFragment.class, null, R.style.Theme_Asteroid);
+                FragmentScenario.launchInContainer(MapFragment.class, null, R.style.AsteroidTheme);
         CompletableFuture<TodoListCollection> todoListCollectionFuture = new CompletableFuture<>();
         todoListCollectionFuture.complete(new TodoListCollection());
         doReturn(todoListCollectionFuture).when(databaseMock).getTodoListCollection();

--- a/app/src/androidTest/java/com/github/steroidteam/todolist/NoteDisplayFragmentTest.java
+++ b/app/src/androidTest/java/com/github/steroidteam/todolist/NoteDisplayFragmentTest.java
@@ -120,7 +120,7 @@ public class NoteDisplayFragmentTest {
 
         scenario =
                 FragmentScenario.launchInContainer(
-                        NoteDisplayFragment.class, null, R.style.Theme_Asteroid);
+                        NoteDisplayFragment.class, null, R.style.AsteroidTheme);
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/steroidteam/todolist/NoteSelectionFragmentTest.java
+++ b/app/src/androidTest/java/com/github/steroidteam/todolist/NoteSelectionFragmentTest.java
@@ -82,7 +82,7 @@ public class NoteSelectionFragmentTest {
 
         scenario =
                 FragmentScenario.launchInContainer(
-                        NoteSelectionFragment.class, null, R.style.Theme_Asteroid);
+                        NoteSelectionFragment.class, null, R.style.AsteroidTheme);
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/steroidteam/todolist/TagTest.java
+++ b/app/src/androidTest/java/com/github/steroidteam/todolist/TagTest.java
@@ -104,7 +104,7 @@ public class TagTest {
         bundle.putSerializable("list_id", UUID.randomUUID());
         scenario =
                 FragmentScenario.launchInContainer(
-                        ItemViewFragment.class, bundle, R.style.Theme_Asteroid);
+                        ItemViewFragment.class, bundle, R.style.AsteroidTheme);
     }
 
     @Test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/asteroid_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Asteroid"
+        android:theme="@style/AsteroidTheme"
         android:requestLegacyExternalStorage="true">
         <meta-data
             android:name="com.google.android.gms.version"

--- a/app/src/main/java/com/github/steroidteam/todolist/view/ItemViewFragment.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/view/ItemViewFragment.java
@@ -228,9 +228,6 @@ public class ItemViewFragment extends Fragment {
         DeleteButtonSetup(position);
         calendarExportButtonSetup(position);
         removeDueDateButtonSetup(position);
-
-        Button closeButton = getView().findViewById(R.id.layout_update_task_close);
-        closeButton.setOnClickListener(this::closeUpdateLayout);
     }
 
     private void SaveButtonSetup(EditText userInput, final int position) {
@@ -287,9 +284,6 @@ public class ItemViewFragment extends Fragment {
 
                             Navigation.findNavController(getView()).navigate(R.id.nav_map);
                         });
-
-        Button closeButton = getView().findViewById(R.id.layout_update_task_close);
-        closeButton.setOnClickListener(this::closeUpdateLayout);
     }
 
     private void removeDueDateButtonSetup(final int position) {

--- a/app/src/main/java/com/github/steroidteam/todolist/view/ItemViewFragment.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/view/ItemViewFragment.java
@@ -53,9 +53,19 @@ public class ItemViewFragment extends Fragment {
         super.onCreate(savedInstanceState);
         View root = inflater.inflate(R.layout.fragment_item_view, container, false);
 
-        // Add a click listener to the "back" button to return to the previous activity.
+        // Add a click listener to the "back" button to return to the previous view (either the
+        // list selection fragment, or the item view if the update layout was open).
         root.findViewById(R.id.back_button)
-                .setOnClickListener(v -> getParentFragmentManager().popBackStack());
+                .setOnClickListener(
+                        v -> {
+                            ConstraintLayout updateLayout =
+                                    getView().findViewById(R.id.layout_update_task);
+                            if (updateLayout.getVisibility() == View.VISIBLE) {
+                                closeUpdateLayout(v);
+                            } else {
+                                getParentFragmentManager().popBackStack();
+                            }
+                        });
 
         EditText newTaskText = root.findViewById(R.id.new_task_text);
         newTaskText.addTextChangedListener(

--- a/app/src/main/java/com/github/steroidteam/todolist/view/NoteDisplayFragment.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/view/NoteDisplayFragment.java
@@ -4,6 +4,7 @@ import static com.github.steroidteam.todolist.util.Utils.dip2px;
 import static com.github.steroidteam.todolist.view.NoteSelectionFragment.NOTE_ID_KEY;
 
 import android.content.DialogInterface;
+import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
@@ -218,7 +219,6 @@ public class NoteDisplayFragment extends Fragment {
     private void initRichEditor(View root) {
         // Rich text editor setup.
         richEditor = root.findViewById(R.id.notedisplay_text_editor);
-        richEditor.setBackgroundColor(ContextCompat.getColor(getContext(), R.color.bg_grey));
         int padding = (int) getResources().getDimension(R.dimen.note_body_padding);
         richEditor.setPadding(padding, padding, padding, 0);
 
@@ -230,6 +230,21 @@ public class NoteDisplayFragment extends Fragment {
                                         getResources().getDisplayMetrics().widthPixels
                                                 / getResources().getDisplayMetrics().density)
                         - 2 * padding;
+
+        switch (getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK) {
+            case Configuration.UI_MODE_NIGHT_YES:
+                // Night mode: black background, white text.
+                richEditor.setBackgroundColor(0);
+                richEditor.setEditorFontColor(ContextCompat.getColor(getContext(), R.color.white));
+                break;
+            case Configuration.UI_MODE_NIGHT_NO:
+            case Configuration.UI_MODE_NIGHT_UNDEFINED:
+                // Light mode: light grey background, black text.
+                richEditor.setBackgroundColor(
+                        ContextCompat.getColor(getContext(), R.color.bg_grey));
+                richEditor.setEditorFontColor(0);
+                break;
+        }
     }
 
     private void setImagePickerListeners(View root) {

--- a/app/src/main/java/com/github/steroidteam/todolist/view/adapter/ParentTaskAdapter.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/view/adapter/ParentTaskAdapter.java
@@ -41,7 +41,7 @@ public class ParentTaskAdapter extends RecyclerView.Adapter<ParentTaskAdapter.Pa
         dateCategoryList.add("Tomorrow");
         dateCategoryList.add("Next 7 days");
         dateCategoryList.add("Later");
-        dateCategoryList.add("Unknown");
+        dateCategoryList.add("No due date");
         dateCategoryList.add("Done");
         sortedDateCategoryList = new ArrayList<>();
     }

--- a/app/src/main/java/com/github/steroidteam/todolist/view/adapter/ParentTaskAdapter.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/view/adapter/ParentTaskAdapter.java
@@ -36,7 +36,7 @@ public class ParentTaskAdapter extends RecyclerView.Adapter<ParentTaskAdapter.Pa
     public ParentTaskAdapter(TodoAdapter.TaskCustomListener listener) {
         this.listener = listener;
         dateCategoryList = new ArrayList<>();
-        dateCategoryList.add("Past");
+        dateCategoryList.add("Past due");
         dateCategoryList.add("Today");
         dateCategoryList.add("Tomorrow");
         dateCategoryList.add("Next 5 days after Tomorrow");

--- a/app/src/main/java/com/github/steroidteam/todolist/view/adapter/ParentTaskAdapter.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/view/adapter/ParentTaskAdapter.java
@@ -39,7 +39,7 @@ public class ParentTaskAdapter extends RecyclerView.Adapter<ParentTaskAdapter.Pa
         dateCategoryList.add("Past due");
         dateCategoryList.add("Today");
         dateCategoryList.add("Tomorrow");
-        dateCategoryList.add("Next 5 days after Tomorrow");
+        dateCategoryList.add("Next 7 days");
         dateCategoryList.add("Later");
         dateCategoryList.add("Unknown");
         dateCategoryList.add("Done");

--- a/app/src/main/java/com/github/steroidteam/todolist/view/adapter/TodoAdapter.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/view/adapter/TodoAdapter.java
@@ -1,6 +1,8 @@
 package com.github.steroidteam.todolist.view.adapter;
 
 import android.content.Context;
+import android.content.res.Resources;
+import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
@@ -11,6 +13,7 @@ import android.text.style.DynamicDrawableSpan;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.ImageSpan;
 import android.text.style.RelativeSizeSpan;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -54,10 +57,17 @@ public class TodoAdapter extends RecyclerView.Adapter<TodoAdapter.TaskHolder> {
         Task currentTask = todoList.getTask(position);
 
         holder.setPosition(taskIntegerMap.get(currentTask));
-        holder.taskBody.setText(currentTask.getBody());
-        if (currentTask.getDueDate() != null) {
-            Context context = holder.itemView.getContext();
 
+        Context context = holder.itemView.getContext();
+        SpannableString taskBodySS = new SpannableString(currentTask.getBody());
+        taskBodySS.setSpan(
+                new ForegroundColorSpan(fetchTextPrimaryColour(context)),
+                0,
+                taskBodySS.length(),
+                Spanned.SPAN_EXCLUSIVE_INCLUSIVE);
+        holder.taskBody.setText(taskBodySS);
+
+        if (currentTask.getDueDate() != null) {
             SpannableString dueDate = createDateSpan(context, currentTask.getDueDate());
 
             // Add some margin between the task's body and the due date.
@@ -195,5 +205,17 @@ public class TodoAdapter extends RecyclerView.Adapter<TodoAdapter.TaskHolder> {
         public void hideDeleteButton() {
             taskDelete.setVisibility(View.GONE);
         }
+    }
+
+    static int fetchTextPrimaryColour(Context context) {
+        TypedValue typedValue = new TypedValue();
+        Resources.Theme theme = context.getTheme();
+        theme.resolveAttribute(android.R.attr.textColorPrimary, typedValue, true);
+        TypedArray arr =
+                context.obtainStyledAttributes(
+                        typedValue.data, new int[] {android.R.attr.textColorPrimary});
+        int primaryColor = arr.getColor(0, -1);
+        arr.recycle();
+        return primaryColor;
     }
 }

--- a/app/src/main/java/com/github/steroidteam/todolist/view/adapter/TodoAdapter.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/view/adapter/TodoAdapter.java
@@ -14,8 +14,8 @@ import android.text.style.RelativeSizeSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.CheckBox;
+import android.widget.ImageButton;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
@@ -158,7 +158,7 @@ public class TodoAdapter extends RecyclerView.Adapter<TodoAdapter.TaskHolder> {
 
         private final TextView taskBody;
         private final CheckBox taskBox;
-        private final Button taskDelete;
+        private final ImageButton taskDelete;
         private int position;
 
         public TaskHolder(@NonNull View itemView) {

--- a/app/src/main/java/com/github/steroidteam/todolist/view/misc/DueDateInputSpan.java
+++ b/app/src/main/java/com/github/steroidteam/todolist/view/misc/DueDateInputSpan.java
@@ -2,15 +2,21 @@ package com.github.steroidteam.todolist.view.misc;
 
 import android.content.Context;
 import android.text.style.ForegroundColorSpan;
-import androidx.core.content.ContextCompat;
+import android.util.TypedValue;
 import com.github.steroidteam.todolist.R;
 import java.util.Date;
 
 public class DueDateInputSpan extends ForegroundColorSpan {
     private final Date date;
 
+    private static int fetchPrimaryColour(Context context) {
+        TypedValue primaryColor = new TypedValue();
+        context.getTheme().resolveAttribute(R.attr.colorPrimary, primaryColor, true);
+        return primaryColor.data;
+    }
+
     public DueDateInputSpan(Context context, Date date) {
-        super(ContextCompat.getColor(context, R.color.dark_blue));
+        super(DueDateInputSpan.fetchPrimaryColour(context));
         this.date = date;
     }
 

--- a/app/src/main/res/drawable/image_icon.xml
+++ b/app/src/main/res/drawable/image_icon.xml
@@ -1,0 +1,5 @@
+<vector android:height="64dp" android:viewportHeight="96"
+    android:viewportWidth="96" android:width="64dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M16,96H80A16,16 0,0 0,96 80V16A16,16 0,0 0,80 0H16A16,16 0,0 0,0 16V80A16,16 0,0 0,16 96ZM80,88H16A8,8 0,0 1,8 80V69.66l20,-20 21.17,21.17a4,4 0,0 0,5.66 0L68,57.66l20,20V80a8,8 0,0 1,-8 8zM16,8h64a8,8 0,0 1,8 8V66.34L70.83,49.17a4,4 0,0 0,-5.66 0L52,62.34 30.83,41.17a4,4 0,0 0,-5.66 0L8,58.34V16a8,8 0,0 1,8 -8z"/>
+    <path android:fillColor="#FF000000" android:pathData="M54,44A14,14 0,1 0,40 30,14 14,0 0,0 54,44ZM54,24a6,6 0,1 1,-6 6,6 6,0 0,1 6,-6z"/>
+</vector>

--- a/app/src/main/res/drawable/location_icon.xml
+++ b/app/src/main/res/drawable/location_icon.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="54dp"
+    android:height="62.35dp"
+    android:viewportWidth="54"
+    android:viewportHeight="62.35">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M27,0A27,27 0,0 0,0 27C0,48.61 24.61,61.16 25.66,61.68L27,62.35 28.34,61.68C29.39,61.16 54,48.61 54,27A27,27 0,0 0,27 0ZM27,55.58C22.17,52.8 6,42.34 6,27a21,21 0,0 1,42 0C48,42.29 31.82,52.79 27,55.58Z"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M27,16A11,11 0,1 0,38 27,11 11,0 0,0 27,16ZM27,32a5,5 0,1 1,5 -5,5 5,0 0,1 -5,5z"/>
+</vector>

--- a/app/src/main/res/drawable/microphone_icon.xml
+++ b/app/src/main/res/drawable/microphone_icon.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="50dp"
+    android:height="64dp"
+    android:viewportWidth="50"
+    android:viewportHeight="64">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M37,27V12a12,12 0,0 0,-24 0v15a12,12 0,0 0,24 0zM19,27V12a6,6 0,0 1,12 0v15a6,6 0,0 1,-12 0z"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m0,23v3.67A25,25 0,0 0,22 51.48V64h6V51.48A25,25 0,0 0,50 26.67V23h-6v3.67a19,19 0,0 1,-38 0V23Z"/>
+</vector>

--- a/app/src/main/res/drawable/rounded_corner_bg_outline_dark.xml
+++ b/app/src/main/res/drawable/rounded_corner_bg_outline_dark.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/black" />
+    <corners android:radius="25dp" />
+    <stroke
+        android:color="?attr/colorPrimary"
+        android:width="3dp" />
+    <padding
+        android:bottom="0dp"
+        android:left="0dp"
+        android:right="0dp"
+        android:top="0dp" />
+</shape>

--- a/app/src/main/res/drawable/rounded_corner_bg_outline_light.xml
+++ b/app/src/main/res/drawable/rounded_corner_bg_outline_light.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/white" />
+    <corners android:radius="25dp" />
+    <stroke
+        android:color="?attr/colorPrimary"
+        android:width="3dp" />
+    <padding
+        android:bottom="0dp"
+        android:left="0dp"
+        android:right="0dp"
+        android:top="0dp" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -18,7 +18,6 @@
         android:fitsSystemWindows="true"
         app:menu="@menu/activity_main_drawer"
         app:headerLayout="@layout/nav_header_main"
-        android:background="@color/white"
         app:itemTextAppearance="@style/DrawerMenuEntry">
 
         <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -18,9 +18,8 @@
         android:fitsSystemWindows="true"
         app:menu="@menu/activity_main_drawer"
         app:headerLayout="@layout/nav_header_main"
-        app:itemTextAppearance="@style/DrawerMenuEntry"
         android:background="@color/white"
-        app:theme="@style/NavigationView">
+        app:itemTextAppearance="@style/DrawerMenuEntry">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/alert_dialog_input.xml
+++ b/app/src/main/res/layout/alert_dialog_input.xml
@@ -9,11 +9,13 @@
         android:id="@+id/alert_dialog_edit_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="24dp"
+        android:autofillHints="@string/title_todo"
+        android:backgroundTint="@color/dark_grey"
+        android:hint="@string/title_todo"
         android:inputType="text"
         android:maxLines="1"
-        android:backgroundTint="@color/dark_grey"
-        android:textCursorDrawable="@drawable/custom_cursor"
-        android:hint="@string/title_todo"
-        android:autofillHints="@string/title_todo" />
+        android:textCursorDrawable="@drawable/custom_cursor" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_audio_recorder.xml
+++ b/app/src/main/res/layout/fragment_audio_recorder.xml
@@ -38,7 +38,7 @@
         android:scaleY="1.2"
         android:layout_gravity="center"
         android:adjustViewBounds="true"
-        android:background="@drawable/rounded_corner_bg"
+        android:background="@drawable/rounded_corner_bg_outline_dark"
         android:scaleType="fitCenter"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_audio_recorder.xml
+++ b/app/src/main/res/layout/fragment_audio_recorder.xml
@@ -38,7 +38,7 @@
         android:scaleY="1.2"
         android:layout_gravity="center"
         android:adjustViewBounds="true"
-        android:background="@drawable/rounded_corner_bg_outline_dark"
+        android:background="@drawable/rounded_corner_bg"
         android:scaleType="fitCenter"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_drawing.xml
+++ b/app/src/main/res/layout/fragment_drawing.xml
@@ -32,7 +32,7 @@
 
         <TextView
             android:id="@+id/drawing_fragment_title"
-            style="@style/ActivityTitle"
+            style="@style/ViewTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/drawing_activity_title"

--- a/app/src/main/res/layout/fragment_item_view.xml
+++ b/app/src/main/res/layout/fragment_item_view.xml
@@ -93,7 +93,7 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
         android:layout_weight="1"
-        style="@style/NewTaskInput"
+        style="@style/BigInput"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">

--- a/app/src/main/res/layout/fragment_item_view.xml
+++ b/app/src/main/res/layout/fragment_item_view.xml
@@ -147,8 +147,10 @@
         android:paddingBottom="15dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar">
+        app:layout_constraintTop_toBottomOf="@+id/toolbar"
+        app:layout_constraintVertical_bias="1.0">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_item_view.xml
+++ b/app/src/main/res/layout/fragment_item_view.xml
@@ -240,32 +240,6 @@
                     android:text="@string/add_location" />
             </LinearLayout>
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:layout_marginBottom="10dp"
-                android:background="@android:color/transparent">
-
-                <Button
-                    android:id="@+id/layout_update_task_save"
-                    style="@style/TaskSaveButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="2dp"
-                    android:layout_weight="1"
-                    android:text="@string/save" />
-
-                <Button
-                    android:id="@+id/layout_update_task_close"
-                    style="@style/TaskUndoButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="2dp"
-                    android:layout_weight="1"
-                    android:text="@string/undo" />
-
-            </LinearLayout>
         </LinearLayout>
 
         <Button
@@ -276,7 +250,18 @@
             android:layout_marginBottom="16dp"
             android:text="@string/delete"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
+
+        <Button
+            android:id="@+id/layout_update_task_save"
+            style="@style/TaskSaveButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/save"
+            app:layout_constraintBottom_toTopOf="@+id/layout_update_task_delete"
+            tools:layout_editor_absoluteX="24dp" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/fragment_item_view.xml
+++ b/app/src/main/res/layout/fragment_item_view.xml
@@ -45,6 +45,7 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="24dp"
             android:src="@android:drawable/stat_notify_more"
+            style="@style/ToolbarActionButton"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/fragment_item_view.xml
+++ b/app/src/main/res/layout/fragment_item_view.xml
@@ -135,11 +135,11 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_update_task"
+        style="@style/TaskUpdateLayout"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
         android:background="@drawable/rounded_corner_just_top_bg"
         android:paddingStart="10dp"
         android:paddingTop="10dp"

--- a/app/src/main/res/layout/fragment_item_view.xml
+++ b/app/src/main/res/layout/fragment_item_view.xml
@@ -204,9 +204,9 @@
                     android:layout_height="0dp"
                     android:layout_marginStart="10dp"
                     android:layout_weight="1"
-                    android:drawableStart="@drawable/calendar_icon"
-                    android:drawablePadding="8dp"
-                    android:drawableTint="@color/dark_grey"
+                    app:icon="@drawable/calendar_icon"
+                    app:iconGravity="textStart"
+                    app:iconTint="@color/dark_grey"
                     android:text="@string/export_to_calendar" />
 
                 <Button
@@ -215,7 +215,11 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="8dp"
-                    android:drawableStart="@drawable/ic_baseline_delete_24_icon"
+                    app:icon="@drawable/ic_baseline_delete_24_icon"
+                    app:iconSize="25dp"
+                    app:iconTint="@color/dark_grey"
+                    app:iconPadding="0dp"
+                    app:iconGravity="textStart"
                     android:text="@string/remove_due_date" />
 
                 <TextView

--- a/app/src/main/res/layout/fragment_item_view.xml
+++ b/app/src/main/res/layout/fragment_item_view.xml
@@ -93,7 +93,7 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
         android:layout_weight="1"
-        android:background="@drawable/rounded_corner_bg"
+        style="@style/NewTaskInput"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">
@@ -123,7 +123,7 @@
             android:layout_marginBottom="7dp"
             android:layout_weight="1"
             android:background="@drawable/rounded_corner_bg"
-            android:backgroundTint="@color/colorPrimary"
+            android:backgroundTint="?attr/colorPrimary"
             android:contentDescription="@string/new_task"
             android:padding="10dp"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_item_view.xml
+++ b/app/src/main/res/layout/fragment_item_view.xml
@@ -232,7 +232,11 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="10dp"
-                    android:drawableStart="@android:drawable/ic_menu_mylocation"
+                    app:icon="@drawable/location_icon"
+                    app:iconSize="17dp"
+                    app:iconTint="@color/dark_grey"
+                    app:iconPadding="5dp"
+                    app:iconGravity="textStart"
                     android:text="@string/add_location" />
             </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_item_view.xml
+++ b/app/src/main/res/layout/fragment_item_view.xml
@@ -31,7 +31,7 @@
 
         <TextView
             android:id="@+id/activity_title"
-            style="@style/ActivityTitle"
+            style="@style/ViewTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_list_selection.xml
+++ b/app/src/main/res/layout/fragment_list_selection.xml
@@ -76,12 +76,13 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
         android:clickable="true"
+        android:contentDescription="@string/new_list_btn_description"
+        android:focusable="true"
         android:src="@drawable/plus_icon"
         app:backgroundTint="?attr/colorPrimary"
         app:elevation="0dp"
+        app:tint="@android:color/white"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:contentDescription="@string/new_list_btn_description"
-        android:focusable="true" />
+        app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_list_selection.xml
+++ b/app/src/main/res/layout/fragment_list_selection.xml
@@ -77,7 +77,7 @@
         android:layout_marginBottom="16dp"
         android:clickable="true"
         android:src="@drawable/plus_icon"
-        app:backgroundTint="@color/dark_blue"
+        app:backgroundTint="?attr/colorPrimary"
         app:elevation="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_list_selection.xml
+++ b/app/src/main/res/layout/fragment_list_selection.xml
@@ -46,11 +46,11 @@
             android:layout_width="28dp"
             android:layout_height="28dp"
             android:layout_marginEnd="24dp"
+            android:contentDescription="@string/search_btn_description"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/search_icon"
-            android:contentDescription="@string/search_btn_description" />
+            app:srcCompat="@drawable/search_icon" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -67,7 +67,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/list_selection_toolbar"/>
+        app:layout_constraintTop_toBottomOf="@+id/list_selection_toolbar" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/create_todo_button"

--- a/app/src/main/res/layout/fragment_list_selection.xml
+++ b/app/src/main/res/layout/fragment_list_selection.xml
@@ -31,7 +31,7 @@
 
         <TextView
             android:id="@+id/activity_title"
-            style="@style/ActivityTitle"
+            style="@style/ViewTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/list_activity_title"

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -20,7 +20,7 @@
         android:iconifiedByDefault="false"
         android:layout_margin="10dp"
         android:elevation="5dp"
-        style="@style/NewTaskInput"
+        style="@style/BigInput"
         />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -20,7 +20,7 @@
         android:iconifiedByDefault="false"
         android:layout_margin="10dp"
         android:elevation="5dp"
-        android:background="@drawable/rounded_corner_search_bg"
+        style="@style/NewTaskInput"
         />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -32,6 +32,7 @@
         android:clickable="true"
         android:layout_alignParentBottom="true"
         android:layout_alignParentEnd="true"
+        android:backgroundTint="?attr/colorPrimary"
         app:srcCompat="?android:attr/textCheckMark"
         android:focusable="true"
         android:contentDescription="@string/save_location" />

--- a/app/src/main/res/layout/fragment_note_display.xml
+++ b/app/src/main/res/layout/fragment_note_display.xml
@@ -24,13 +24,12 @@
 
         <ImageButton
             android:id="@+id/camera_button"
+            style="@style/ToolbarActionButton"
             android:layout_width="28dp"
             android:layout_height="28dp"
-            android:layout_marginTop="1dp"
-            android:layout_marginEnd="1dp"
+            android:padding="3dp"
             android:contentDescription="@string/add_header_photo"
-            android:scaleX="1.2"
-            android:scaleY="1.2"
+            android:tint="@color/white"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:srcCompat="@drawable/image_icon" />
@@ -56,7 +55,9 @@
             android:layout_marginTop="1dp"
             android:layout_marginEnd="20dp"
             android:adjustViewBounds="true"
+            android:padding="3dp"
             android:background="@android:color/transparent"
+            android:tint="@color/white"
             android:contentDescription="@string/location_btn_description"
             android:scaleType="fitCenter"
             app:layout_constraintEnd_toStartOf="@+id/camera_button"

--- a/app/src/main/res/layout/fragment_note_display.xml
+++ b/app/src/main/res/layout/fragment_note_display.xml
@@ -61,7 +61,7 @@
             android:scaleType="fitCenter"
             app:layout_constraintEnd_toStartOf="@+id/camera_button"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@android:drawable/ic_menu_mylocation" />
+            app:srcCompat="@drawable/location_icon" />
 
         <ImageButton
             android:id="@+id/audio_button"

--- a/app/src/main/res/layout/fragment_note_display.xml
+++ b/app/src/main/res/layout/fragment_note_display.xml
@@ -68,15 +68,16 @@
             android:layout_width="28dp"
             android:layout_height="28dp"
             android:layout_gravity="center"
-            android:layout_marginTop="1dp"
             android:layout_marginEnd="20dp"
+            android:padding="3dp"
             android:adjustViewBounds="true"
             android:background="@android:color/transparent"
+            android:tint="@color/white"
             android:contentDescription="@string/audio_btn_description"
             android:scaleType="fitCenter"
             app:layout_constraintEnd_toStartOf="@+id/location_button"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@android:drawable/ic_btn_speak_now" />
+            app:srcCompat="@drawable/microphone_icon" />
 
         <TextView
             android:id="@+id/note_title"

--- a/app/src/main/res/layout/fragment_note_display.xml
+++ b/app/src/main/res/layout/fragment_note_display.xml
@@ -33,7 +33,7 @@
             android:scaleY="1.2"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@android:drawable/ic_menu_camera" />
+            app:srcCompat="@drawable/image_icon" />
 
         <ImageButton
             android:id="@+id/back_button"

--- a/app/src/main/res/layout/fragment_note_selection.xml
+++ b/app/src/main/res/layout/fragment_note_selection.xml
@@ -66,9 +66,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar">
-
-    </androidx.recyclerview.widget.RecyclerView>
+        app:layout_constraintTop_toBottomOf="@+id/toolbar" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/create_note_button"

--- a/app/src/main/res/layout/fragment_note_selection.xml
+++ b/app/src/main/res/layout/fragment_note_selection.xml
@@ -79,6 +79,7 @@
         android:focusable="true"
         android:src="@drawable/plus_icon"
         app:backgroundTint="?attr/colorPrimary"
+        app:tint="@android:color/white"
         app:elevation="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/fragment_note_selection.xml
+++ b/app/src/main/res/layout/fragment_note_selection.xml
@@ -31,7 +31,7 @@
 
         <TextView
             android:id="@+id/activity_title"
-            style="@style/ActivityTitle"
+            style="@style/ViewTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/note_activity_title"

--- a/app/src/main/res/layout/fragment_note_selection.xml
+++ b/app/src/main/res/layout/fragment_note_selection.xml
@@ -80,7 +80,7 @@
         android:contentDescription="@string/new_note_btn_description"
         android:focusable="true"
         android:src="@drawable/plus_icon"
-        app:backgroundTint="@color/dark_blue"
+        app:backgroundTint="?attr/colorPrimary"
         app:elevation="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/layout_note_item.xml
+++ b/app/src/main/res/layout/layout_note_item.xml
@@ -6,13 +6,13 @@
     android:layout_height="wrap_content"
     app:cardElevation="0dp"
     app:cardCornerRadius="25dp"
-    android:layout_marginBottom="20dp">
+    android:layout_marginBottom="20dp"
+    style="@style/SelectionList.CardView">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/layout_note"
-        style="@style/SelectionList.Entry">
+        android:id="@+id/layout_note">
 
         <ImageView
             android:id="@+id/layout_note_picture"
@@ -32,6 +32,7 @@
             android:layout_marginStart="8dp"
             android:layout_marginTop="8dp"
             android:text=""
+            android:background="@android:color/transparent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/layout_note_picture" />
 
@@ -43,6 +44,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginTop="8dp"
             android:text="@string/date_placeholder"
+            android:background="@android:color/transparent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/layout_note_title" />
 

--- a/app/src/main/res/layout/layout_task_item.xml
+++ b/app/src/main/res/layout/layout_task_item.xml
@@ -2,7 +2,6 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginStart="8dp"
     android:layout_marginTop="0dp"
     android:layout_marginEnd="8dp"
     android:background="@android:color/transparent">
@@ -12,6 +11,7 @@
         style="@style/TaskEntryCheckbox"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="-5dp"
         android:layout_alignParentStart="true"
         android:layout_centerInParent="true" />
 

--- a/app/src/main/res/layout/layout_task_item.xml
+++ b/app/src/main/res/layout/layout_task_item.xml
@@ -24,7 +24,11 @@
         android:layout_centerInParent="true"
         android:layout_toEndOf="@+id/layout_task_checkbox"
         android:background="@android:color/transparent"
-        android:ellipsize="end" />
+        android:ellipsize="end"
+        android:fontFamily="@font/nunitosans_semibold"
+        android:includeFontPadding="false"
+        android:textColor="@color/white"
+        android:textSize="20sp" />
 
     <ImageButton
         android:id="@+id/layout_task_delete_button"

--- a/app/src/main/res/layout/layout_task_item.xml
+++ b/app/src/main/res/layout/layout_task_item.xml
@@ -25,12 +25,15 @@
         android:layout_toEndOf="@+id/layout_task_checkbox"
         android:ellipsize="end" />
 
-    <Button
+    <ImageButton
         android:id="@+id/layout_task_delete_button"
+        style="@style/DeleteButtonInRecyclerView"
         android:layout_width="30dp"
         android:layout_height="30dp"
         android:layout_alignParentEnd="true"
         android:layout_centerInParent="true"
-        style="@style/DeleteButtonInRecyclerView"
+        android:contentDescription="@string/delete"
+        android:scaleX="0.7"
+        android:scaleY="0.7"
         android:visibility="gone" />
 </RelativeLayout>

--- a/app/src/main/res/layout/layout_task_item.xml
+++ b/app/src/main/res/layout/layout_task_item.xml
@@ -23,6 +23,7 @@
         android:layout_alignParentEnd="true"
         android:layout_centerInParent="true"
         android:layout_toEndOf="@+id/layout_task_checkbox"
+        android:background="@android:color/transparent"
         android:ellipsize="end" />
 
     <ImageButton

--- a/app/src/main/res/layout/layout_todo_list_item.xml
+++ b/app/src/main/res/layout/layout_todo_list_item.xml
@@ -9,14 +9,13 @@
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/white">
+        android:layout_height="match_parent">
 
         <TextView
             android:id="@+id/layout_todo_list_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/white"
+            android:background="@android:color/transparent"
             style="@style/SelectionList.Entry.Title"/>
 
     </RelativeLayout>

--- a/app/src/main/res/layout/parent_recycler_view_task_item.xml
+++ b/app/src/main/res/layout/parent_recycler_view_task_item.xml
@@ -12,6 +12,8 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="24dp"
+        android:fontFamily="@font/nunitosans_bold"
+        android:textAllCaps="true"
         android:textColor="?attr/colorPrimary"
         android:textSize="16sp"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/parent_recycler_view_task_item.xml
+++ b/app/src/main/res/layout/parent_recycler_view_task_item.xml
@@ -19,19 +19,25 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/child_task_recycler_view"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:background="@drawable/rounded_corner_bg"
-        android:paddingStart="5dp"
-        android:paddingTop="10dp"
-        android:paddingBottom="10dp"
+    <androidx.cardview.widget.CardView
+        android:layout_marginBottom="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.01"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/date_category"
-        tools:listitem="layout_task_item" />
+        android:layout_marginTop="8dp"
+        android:paddingStart="5dp"
+        android:paddingEnd="5dp"
+        android:paddingBottom="10dp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        style="@style/SelectionList.CardView">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/child_task_recycler_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:listitem="layout_task_item" />
+    </androidx.cardview.widget.CardView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/parent_recycler_view_task_item.xml
+++ b/app/src/main/res/layout/parent_recycler_view_task_item.xml
@@ -12,7 +12,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="24dp"
-        android:textColor="@color/dark_blue"
+        android:textColor="?attr/colorPrimary"
         android:textSize="16sp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -6,6 +6,12 @@
         <item name="android:windowLightStatusBar">false</item>
     </style>
 
+    <style name="ToolbarActionButton">
+        <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
+        <item name="android:tint">@android:color/white</item>
+        <item name="android:scaleType">fitCenter</item>
+    </style>
+
     <style name="BigInput">
         <item name="android:background">@drawable/rounded_corner_bg_outline_dark</item>
     </style>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -2,4 +2,8 @@
     <style name="AsteroidTheme" parent="Theme.MaterialComponents.NoActionBar">
         <item name="android:windowBackground">@android:color/black</item>
     </style>
+
+    <style name="NewTaskInput">
+        <item name="android:background">@drawable/rounded_corner_bg_outline_dark</item>
+    </style>
 </resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -2,6 +2,8 @@
     <style name="AsteroidTheme" parent="Theme.MaterialComponents.NoActionBar">
         <item name="colorPrimary">#854FCF</item>
         <item name="android:windowBackground">@android:color/black</item>
+        <item name="android:statusBarColor">@android:color/black</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 
     <style name="BigInput">

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -6,4 +6,8 @@
     <style name="BigInput">
         <item name="android:background">@drawable/rounded_corner_bg_outline_dark</item>
     </style>
+
+    <style name="TaskUpdateLayout">
+        <item name="android:backgroundTint">@android:color/black</item>
+    </style>
 </resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,5 @@
+<resources>
+    <style name="AsteroidTheme" parent="Theme.MaterialComponents.NoActionBar">
+        <item name="android:windowBackground">@android:color/black</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,5 +1,6 @@
 <resources>
     <style name="AsteroidTheme" parent="Theme.MaterialComponents.NoActionBar">
+        <item name="colorPrimary">#854FCF</item>
         <item name="android:windowBackground">@android:color/black</item>
     </style>
 

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -3,7 +3,7 @@
         <item name="android:windowBackground">@android:color/black</item>
     </style>
 
-    <style name="NewTaskInput">
+    <style name="BigInput">
         <item name="android:background">@drawable/rounded_corner_bg_outline_dark</item>
     </style>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="activity_title">#FF000000</color>
     <color name="dark_blue">#FF035AA6</color>
     <color name="dark_grey">#555555</color>
     <color name="light_grey">#ACABAB</color>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -39,7 +39,6 @@
     </style>
 
     <style name="ActivityTitle">
-        <item name="android:textColor">@color/activity_title</item>
         <item name="android:textSize">30sp</item>
         <item name="android:fontFamily">@font/nunitosans_bold</item>
     </style>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -38,7 +38,7 @@
         <item name="android:textColor">@color/dark_grey</item>
     </style>
 
-    <style name="ActivityTitle">
+    <style name="ViewTitle">
         <item name="android:textSize">30sp</item>
         <item name="android:fontFamily">@font/nunitosans_bold</item>
     </style>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -102,6 +102,11 @@
         <item name="contentPaddingRight">15dp</item>
         <item name="contentPaddingTop">14dp</item>
     </style>
+
+    <style name="NewTaskInput">
+        <item name="android:background">@drawable/rounded_corner_bg_outline_light</item>
+    </style>
+
     <!-- Dialog Theme -->
     <style name="Dialog" parent="Theme.AppCompat.Dialog.Alert">
         <item name="android:textColorPrimary">@color/dark_blue</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -112,22 +112,16 @@
 
     <style name="TaskSaveButton">
         <item name="android:fontFamily">@font/nunitosans_semibold</item>
-        <item name="android:background">@drawable/rounded_corner_bg</item>
-        <item name="android:backgroundTint">@color/colorPrimary</item>
-        <item name="android:textColor">@color/white</item>
     </style>
 
     <style name="TaskDeleteButton">
         <item name="android:fontFamily">@font/nunitosans_semibold</item>
-        <item name="android:background">@color/red_pastel</item>
-        <item name="android:textColor">@color/white</item>
+        <item name="android:backgroundTint">@android:color/holo_red_dark</item>
     </style>
 
     <style name="TaskUndoButton">
         <item name="android:fontFamily">@font/nunitosans_semibold</item>
-        <item name="android:background">@drawable/rounded_corner_bg</item>
         <item name="android:backgroundTint">@color/light_grey</item>
-        <item name="android:textColor">@color/white</item>
     </style>
 
     <style name="DeleteButtonInRecyclerView">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -132,7 +132,7 @@
 
     <style name="DeleteButtonInRecyclerView">
         <item name="android:fontFamily">@font/nunitosans_semibold</item>
-        <item name="android:background">@drawable/rounded_corner_bg</item>
+        <item name="android:background">@drawable/rounded_corner_bg_outline_dark</item>
         <item name="android:backgroundTint">@color/light_grey</item>
         <item name="android:textColor">@color/white</item>
         <item name="android:text">X</item>
@@ -140,7 +140,7 @@
 
     <style name="TagInList">
         <item name="android:fontFamily">@font/nunitosans_semibold</item>
-        <item name="android:background">@drawable/rounded_corner_bg</item>
+        <item name="android:background">@drawable/rounded_corner_bg_outline_dark</item>
         <item name="android:textColor">@color/dark_grey</item>
         <item name="android:paddingLeft">10dp</item>
         <item name="android:paddingTop">4dp</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -21,15 +21,9 @@
         <item name="android:padding">36dp</item>
     </style>
 
-
     <style name="NunitoTextViewStyle">
         <item name="android:fontFamily">@font/nunitosans_regular</item>
         <item name="android:background">@android:color/transparent</item>
-    </style>
-
-    <style name="NavigationView">
-        <item name="android:background">@color/white</item>
-        <item name="itemBackground">@color/white</item>
     </style>
 
     <style name="DrawerMenuEntry">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -103,11 +103,15 @@
     <!-- Dialog Theme -->
     <style name="Dialog" parent="Theme.AppCompat.Dialog.Alert">
         <item name="android:textColorPrimary">?attr/colorPrimary</item>
-        <item name="colorAccent">@android:color/black</item>
+        <item name="buttonBarPositiveButtonStyle">@style/DialogButton</item>
+        <item name="buttonBarNegativeButtonStyle">@style/DialogButton</item>
         <item name="textColorAlertDialogListItem">@android:color/black</item>
         <item name="android:text">@font/nunitosans_bold</item>
         <item name="android:textSize">17sp</item>
         <item name="android:background">@drawable/rounded_corner_bg</item>
+    </style>
+    <style name="DialogButton">
+        <item name="android:background">@android:color/transparent</item>
     </style>
 
     <style name="TaskSaveButton">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -58,7 +58,7 @@
 
     <style name="SelectionList.Entry.Title">
         <item name="android:fontFamily">@font/nunitosans_bold</item>
-        <item name="android:textColor">@color/dark_blue</item>
+        <item name="android:textColor">?attr/colorPrimary</item>
         <item name="android:textSize">22sp</item>
         <item name="android:padding">0dp</item>
     </style>
@@ -102,7 +102,7 @@
 
     <!-- Dialog Theme -->
     <style name="Dialog" parent="Theme.AppCompat.Dialog.Alert">
-        <item name="android:textColorPrimary">@color/dark_blue</item>
+        <item name="android:textColorPrimary">?attr/colorPrimary</item>
         <item name="colorAccent">@android:color/black</item>
         <item name="textColorAlertDialogListItem">@android:color/black</item>
         <item name="android:text">@font/nunitosans_bold</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -7,6 +7,8 @@
         <item name="android:textViewStyle">@style/NunitoTextViewStyle</item>
 
         <item name="android:windowBackground">@color/bg_grey</item>
+        <item name="android:statusBarColor">@color/bg_grey</item>
+        <item name="android:windowLightStatusBar">true</item>
     </style>
 
     <style name="LoginTheme" parent="FirebaseUI">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -31,7 +31,7 @@
         <item name="android:textSize">20sp</item>
     </style>
 
-    <style name="BorderlessButton">
+    <style name="BorderlessButton" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:background">@android:color/transparent</item>
         <item name="android:fontFamily">@font/nunitosans_semibold</item>
         <item name="android:textAllCaps">false</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,14 +1,12 @@
 <resources>
-    <!-- Base application theme. -->
     <style name="AsteroidTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/dark_blue</item>
         <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
-        <item name="android:windowBackground">@color/bg_grey</item>
-        <!-- Status bar color. -->
         <!-- Customize your theme here. -->
         <item name="android:textViewStyle">@style/NunitoTextViewStyle</item>
+
+        <item name="android:windowBackground">@color/bg_grey</item>
     </style>
 
     <style name="LoginTheme" parent="FirebaseUI">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -103,7 +103,7 @@
         <item name="contentPaddingTop">14dp</item>
     </style>
 
-    <style name="NewTaskInput">
+    <style name="BigInput">
         <item name="android:background">@drawable/rounded_corner_bg_outline_light</item>
     </style>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -135,7 +135,8 @@
         <item name="android:background">@drawable/rounded_corner_bg_outline_dark</item>
         <item name="android:backgroundTint">@color/light_grey</item>
         <item name="android:textColor">@color/white</item>
-        <item name="android:text">X</item>
+        <item name="srcCompat">@drawable/plus_icon</item>
+        <item name="android:rotation">45</item>
     </style>
 
     <style name="TagInList">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="Theme.Asteroid" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="AsteroidTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/dark_blue</item>
         <item name="colorOnPrimary">@color/white</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -84,7 +84,7 @@
 
     <style name="ToolbarActionButton">
         <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
-        <item name="android:tint">#000000</item>
+        <item name="android:tint">@android:color/black</item>
         <item name="android:scaleType">fitCenter</item>
     </style>
     <style name="SelectionList.CardView">


### PR DESCRIPTION
This PR implements the theme used when the device is in dark mode, as well as
some extra UI enhancements.

To test the new theme, I recommend adding the "dark theme" button to your
device's toolbar, so you can easily switch between dark/light theme.

You can enable it by extending the notification panel, tapping the "pencil" button and then dragging the "Dark theme" tile.

![quick settings view](https://user-images.githubusercontent.com/7356565/120563455-ee327a00-c408-11eb-8a15-92d2d3a7f496.png)

Looks like a lot of commits but do not worry, they are very small! :)