### PR TITLE
Fixes non-focused menu item when navigating to a deep destination.

### DIFF
--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -6,12 +6,12 @@
 
     <group android:checkableBehavior="single">
         <item
-            android:id="@+id/nav_list_selection"
+            android:id="@+id/nav_todos"
             android:icon="@drawable/tick"
             android:title="@string/menu_todo_lists" />
 
         <item
-            android:id="@+id/nav_note_selection"
+            android:id="@+id/nav_notes"
             android:icon="@drawable/note"
             android:title="@string/menu_notes" />
     </group>

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -3,60 +3,61 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/mobile_navigation"
-    app:startDestination="@+id/nav_list_selection">
+    app:startDestination="@+id/nav_todos">
 
-    <fragment
-        android:id="@+id/nav_list_selection"
-        android:name="com.github.steroidteam.todolist.view.ListSelectionFragment"
-        android:label="@string/menu_todo_lists"
-        tools:layout="@layout/fragment_list_selection" >
-        <action
-            android:id="@+id/action_nav_list_selection_to_nav_item_view"
-            app:destination="@id/nav_item_view" />
-    </fragment>
-
-    <fragment
-        android:id="@+id/nav_item_view"
-        android:name="com.github.steroidteam.todolist.view.ItemViewFragment"
-        tools:layout="@layout/fragment_item_view" />
-
-    <fragment
-        android:id="@+id/nav_note_selection"
-        android:name="com.github.steroidteam.todolist.view.NoteSelectionFragment"
-        android:label="@string/menu_notes"
-        tools:layout="@layout/fragment_note_selection" >
-        <action
-            android:id="@+id/action_nav_note_selection_to_nav_note_display"
-            app:destination="@id/nav_note_display" />
-    </fragment>
-
-    <fragment
-        android:id="@+id/nav_note_display"
-        android:name="com.github.steroidteam.todolist.view.NoteDisplayFragment"
-        tools:layout="@layout/fragment_note_display" >
-        <action
-            android:id="@+id/action_nav_note_display_to_nav_map"
-            app:destination="@id/nav_map" />
-        <action
-            android:id="@+id/action_nav_note_display_to_nav_audio"
-            app:destination="@id/nav_audio" />
-        <action
-            android:id="@+id/action_nav_note_display_to_nav_drawing"
-            app:destination="@id/nav_drawing" />
-    </fragment>
-
-    <fragment
-        android:id="@+id/nav_map"
-        android:name="com.github.steroidteam.todolist.view.MapFragment"
-        tools:layout="@layout/fragment_map" />
-
-    <fragment
-        android:id="@+id/nav_audio"
-        android:name="com.github.steroidteam.todolist.view.AudioRecorderFragment"
-        tools:layout="@layout/fragment_audio_recorder" />
-    <fragment
-        android:id="@+id/nav_drawing"
-        android:name="com.github.steroidteam.todolist.view.DrawingFragment"
-        tools:layout="@layout/fragment_drawing" />
+    <navigation android:id="@+id/nav_notes"
+        app:startDestination="@id/nav_note_selection">
+        <fragment
+            android:id="@+id/nav_note_selection"
+            android:name="com.github.steroidteam.todolist.view.NoteSelectionFragment"
+            android:label="@string/menu_notes"
+            tools:layout="@layout/fragment_note_selection">
+            <action
+                android:id="@+id/action_nav_note_selection_to_nav_note_display"
+                app:destination="@id/nav_note_display" />
+        </fragment>
+        <fragment
+            android:id="@+id/nav_note_display"
+            android:name="com.github.steroidteam.todolist.view.NoteDisplayFragment"
+            tools:layout="@layout/fragment_note_display">
+            <action
+                android:id="@+id/action_nav_note_display_to_nav_map"
+                app:destination="@id/nav_map" />
+            <action
+                android:id="@+id/action_nav_note_display_to_nav_audio"
+                app:destination="@id/nav_audio" />
+            <action
+                android:id="@+id/action_nav_note_display_to_nav_drawing"
+                app:destination="@id/nav_drawing" />
+        </fragment>
+        <fragment
+            android:id="@+id/nav_map"
+            android:name="com.github.steroidteam.todolist.view.MapFragment"
+            tools:layout="@layout/fragment_map" />
+        <fragment
+            android:id="@+id/nav_audio"
+            android:name="com.github.steroidteam.todolist.view.AudioRecorderFragment"
+            tools:layout="@layout/fragment_audio_recorder" />
+        <fragment
+            android:id="@+id/nav_drawing"
+            android:name="com.github.steroidteam.todolist.view.DrawingFragment"
+            tools:layout="@layout/fragment_drawing" />
+    </navigation>
+    <navigation android:id="@+id/nav_todos"
+        app:startDestination="@id/nav_list_selection">
+        <fragment
+            android:id="@+id/nav_list_selection"
+            android:name="com.github.steroidteam.todolist.view.ListSelectionFragment"
+            android:label="@string/menu_todo_lists"
+            tools:layout="@layout/fragment_list_selection">
+            <action
+                android:id="@+id/action_nav_list_selection_to_nav_item_view"
+                app:destination="@id/nav_item_view" />
+        </fragment>
+        <fragment
+            android:id="@+id/nav_item_view"
+            android:name="com.github.steroidteam.todolist.view.ItemViewFragment"
+            tools:layout="@layout/fragment_item_view" />
+    </navigation>
 
 </navigation>


### PR DESCRIPTION
Related issue : #192 

Now, when we navigate into deep fragment destination and come back and try to open the menu drawer, the corresponding menu item is still focused as it should be.